### PR TITLE
Add complexity driven goal and phase scaling

### DIFF
--- a/codex/goals/establish-goals.checklist.md
+++ b/codex/goals/establish-goals.checklist.md
@@ -5,7 +5,7 @@
 - [ ] I listed ambiguities and separated blocking vs non-blocking.
 - [ ] I asked targeted questions for blocking ambiguities.
 - [ ] Any assumptions are explicitly labeled.
-- [ ] Goals are 0–5 and verifiable.
+- [ ] Goals are 1-10 and verifiable.
 - [ ] Non-goals are explicit.
 - [ ] Success criteria are objective and tied to goals.
 - [ ] Status is set correctly: draft / blocked / ready-for-confirmation / locked.

--- a/codex/goals/establish-goals.template.md
+++ b/codex/goals/establish-goals.template.md
@@ -38,15 +38,18 @@
 1.
 2.
 
-## Goals (0–5, verifiable)
-
-> If ambiguity is blocking, it is valid to have 0 goals.
+## Goals (1-10, verifiable)
 
 1.
 2.
 3.
 4.
 5.
+6.
+7.
+8.
+9.
+10.
 
 ## Non-goals (explicit exclusions)
 

--- a/codex/prompts/establish-goals.md
+++ b/codex/prompts/establish-goals.md
@@ -26,7 +26,7 @@ You MUST NOT proceed past `establish-goals`.
 
 ## Hard stop rule (mandatory)
 
-If the current iteration produces **ZERO goals**:
+If the current iteration cannot produce **at least one verifiable goal**:
 
 - mark the iteration as `blocked`
 - ask only the blocking clarification questions

--- a/codex/rules/expand-task-spec.rules
+++ b/codex/rules/expand-task-spec.rules
@@ -102,6 +102,33 @@ prefix_rule(
 # -------------------------
 
 prefix_rule(
+    pattern=["/Users/eric/.codex/scripts/complexity-score.sh"],
+    decision="allow",
+    justification="Compute deterministic complexity level and recommended goals/phases from scored JSON signals.",
+    match=[
+        "/Users/eric/.codex/scripts/complexity-score.sh ./tasks/add-feature-x/complexity-signals.json --format json",
+    ],
+)
+
+prefix_rule(
+    pattern=["./.codex/scripts/complexity-score.sh"],
+    decision="allow",
+    justification="Compute deterministic complexity level and recommended goals/phases from scored JSON signals (canonical repo path).",
+    match=[
+        "./.codex/scripts/complexity-score.sh ./tasks/add-feature-x/complexity-signals.json --format json",
+    ],
+)
+
+prefix_rule(
+    pattern=["./codex/scripts/complexity-score.sh"],
+    decision="allow",
+    justification="Compute deterministic complexity level and recommended goals/phases from scored JSON signals (repo-local fallback path).",
+    match=[
+        "./codex/scripts/complexity-score.sh ./tasks/add-feature-x/complexity-signals.json --format json",
+    ],
+)
+
+prefix_rule(
     pattern=["/Users/eric/.codex/scripts/prepare-phased-impl-archive.sh"],
     decision="allow",
     justification="Archive previous Stage 3 planning artifacts using short-hash archive GUIDs before restart.",

--- a/codex/scripts/complexity-score.sh
+++ b/codex/scripts/complexity-score.sh
@@ -1,0 +1,388 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+usage() {
+  cat <<EOF
+Usage: ${SCRIPT_NAME} <signals-json-file> [--format shell|json|markdown]
+
+Input JSON schema (required keys):
+{
+  "scope": 0|2|4,
+  "behavior": 0|2|4,
+  "dependency": 0|2|4,
+  "uncertainty": 0|2|4,
+  "verification": 0|2|4,
+  "evidence": {
+    "scope": "<trimmed non-empty string with files= and surface=>",
+    "behavior": "<trimmed non-empty string>",
+    "dependency": "<trimmed non-empty string with interfaces=>",
+    "uncertainty": "<trimmed non-empty string>",
+    "verification": "<trimmed non-empty string with checks=>",
+    "guardrails": "<trimmed non-empty string>"
+  },
+  "guardrails": {
+    "no_schema_or_api_contract_change": true|false,
+    "no_new_external_dependencies": true|false,
+    "localized_surface": true|false,
+    "reversible_with_straightforward_verification": true|false
+  },
+  "overrides": {
+    "goals": <optional int in 1..10>,
+    "phases": <optional int in 2..20>,
+    "reason": "<required non-empty string when goals/phases override is used>"
+  }
+}
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+INPUT_FILE="${1:-}"
+FORMAT_FLAG="${2:---format}"
+FORMAT_VALUE_INPUT="${3:-shell}"
+
+if [[ -z "${INPUT_FILE}" ]]; then
+  usage
+  exit 2
+fi
+
+if [[ ! -f "${INPUT_FILE}" ]]; then
+  echo "ERROR: Missing signals file: ${INPUT_FILE}"
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required by ${SCRIPT_NAME}"
+  exit 1
+fi
+
+if ! jq -e . "${INPUT_FILE}" >/dev/null 2>&1; then
+  echo "ERROR: invalid JSON in ${INPUT_FILE}"
+  exit 1
+fi
+
+if [[ "${FORMAT_FLAG}" != "--format" ]]; then
+  echo "ERROR: second argument must be --format"
+  exit 2
+fi
+
+FORMAT_VALUE="${FORMAT_VALUE_INPUT}"
+if [[ "${FORMAT_VALUE}" != "shell" && "${FORMAT_VALUE}" != "json" && "${FORMAT_VALUE}" != "markdown" ]]; then
+  echo "ERROR: format must be --format shell, --format json, or --format markdown"
+  exit 2
+fi
+
+trim_whitespace() {
+  sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+}
+
+validate_score() {
+  local key="$1"
+  local value
+  if ! jq -e ".${key} | (type == \"number\") and (. == 0 or . == 2 or . == 4)" "${INPUT_FILE}" >/dev/null 2>&1; then
+    value="$(jq -r ".${key} // \"<missing>\"" "${INPUT_FILE}" 2>/dev/null || echo "<invalid>")"
+    echo "ERROR: '${key}' must be one of 0, 2, 4 (found '${value}')"
+    exit 1
+  fi
+}
+
+validate_evidence() {
+  local key="$1"
+  local value
+  if ! jq -e ".evidence.${key} | type == \"string\"" "${INPUT_FILE}" >/dev/null 2>&1; then
+    echo "ERROR: Missing required evidence line '.evidence.${key}'"
+    exit 1
+  fi
+  value="$(jq -r ".evidence.${key}" "${INPUT_FILE}" | trim_whitespace)"
+  if [[ -z "${value}" ]]; then
+    echo "ERROR: Missing required evidence line '.evidence.${key}'"
+    exit 1
+  fi
+  echo "${value}"
+}
+
+require_evidence_token() {
+  local key="$1"
+  local value="$2"
+  local token="$3"
+  if ! grep -Eq "${token}" <<<"${value}"; then
+    echo "ERROR: evidence.${key} must contain '${token}'"
+    exit 1
+  fi
+}
+
+validate_guardrail_bool() {
+  local key="$1"
+  local value
+  if ! jq -e ".guardrails.${key} | type == \"boolean\"" "${INPUT_FILE}" >/dev/null 2>&1; then
+    echo "ERROR: '.guardrails.${key}' must be true or false"
+    exit 1
+  fi
+  value="$(jq -r ".guardrails.${key}" "${INPUT_FILE}")"
+  if [[ "${value}" != "true" && "${value}" != "false" ]]; then
+    echo "ERROR: '.guardrails.${key}' must be true or false"
+    exit 1
+  fi
+}
+
+validate_score "scope"
+validate_score "behavior"
+validate_score "dependency"
+validate_score "uncertainty"
+validate_score "verification"
+
+scope_evidence="$(validate_evidence "scope")"
+behavior_evidence="$(validate_evidence "behavior")"
+dependency_evidence="$(validate_evidence "dependency")"
+uncertainty_evidence="$(validate_evidence "uncertainty")"
+verification_evidence="$(validate_evidence "verification")"
+guardrails_evidence="$(validate_evidence "guardrails")"
+
+require_evidence_token "scope" "${scope_evidence}" 'files='
+require_evidence_token "scope" "${scope_evidence}" 'surface='
+require_evidence_token "dependency" "${dependency_evidence}" 'interfaces='
+require_evidence_token "verification" "${verification_evidence}" 'checks='
+
+validate_guardrail_bool "no_schema_or_api_contract_change"
+validate_guardrail_bool "no_new_external_dependencies"
+validate_guardrail_bool "localized_surface"
+validate_guardrail_bool "reversible_with_straightforward_verification"
+
+scope="$(jq -er '.scope' "${INPUT_FILE}")"
+behavior="$(jq -er '.behavior' "${INPUT_FILE}")"
+dependency="$(jq -er '.dependency' "${INPUT_FILE}")"
+uncertainty="$(jq -er '.uncertainty' "${INPUT_FILE}")"
+verification="$(jq -er '.verification' "${INPUT_FILE}")"
+
+no_schema_or_api_contract_change="$(jq -r '.guardrails.no_schema_or_api_contract_change' "${INPUT_FILE}")"
+no_new_external_dependencies="$(jq -r '.guardrails.no_new_external_dependencies' "${INPUT_FILE}")"
+localized_surface="$(jq -r '.guardrails.localized_surface' "${INPUT_FILE}")"
+reversible_with_straightforward_verification="$(jq -r '.guardrails.reversible_with_straightforward_verification' "${INPUT_FILE}")"
+
+force_l1="false"
+if [[ "${no_schema_or_api_contract_change}" == "true" \
+   && "${no_new_external_dependencies}" == "true" \
+   && "${localized_surface}" == "true" \
+   && "${reversible_with_straightforward_verification}" == "true" ]]; then
+  force_l1="true"
+fi
+
+if [[ "${force_l1}" == "true" ]] && (( scope > 2 || behavior > 2 || dependency > 2 || uncertainty > 2 || verification > 2 )); then
+  echo "ERROR: Forced L1 guardrails conflict with high-complexity signals; all signals must be <=2 when forcing L1."
+  exit 1
+fi
+
+total_score=$((scope + behavior + dependency + uncertainty + verification))
+
+level="L1"
+level_name="surgical"
+goals_min=1
+goals_max=2
+phases_min=2
+phases_max=3
+
+if [[ "${force_l1}" != "true" ]]; then
+  if (( total_score <= 4 )); then
+    level="L1"; level_name="surgical"; goals_min=1; goals_max=2; phases_min=2; phases_max=3
+  elif (( total_score <= 8 )); then
+    level="L2"; level_name="focused"; goals_min=2; goals_max=4; phases_min=3; phases_max=6
+  elif (( total_score <= 12 )); then
+    level="L3"; level_name="multi-surface"; goals_min=3; goals_max=6; phases_min=6; phases_max=10
+  elif (( total_score <= 16 )); then
+    level="L4"; level_name="cross-system"; goals_min=5; goals_max=8; phases_min=10; phases_max=15
+  else
+    level="L5"; level_name="program"; goals_min=7; goals_max=10; phases_min=15; phases_max=20
+  fi
+fi
+
+goals_midpoint=$(((goals_min + goals_max) / 2))
+phases_midpoint=$(((phases_min + phases_max) / 2))
+
+goals_adjust=0
+phases_adjust=0
+if (( uncertainty == 4 )); then
+  goals_adjust=$((goals_adjust + 1))
+  phases_adjust=$((phases_adjust + 1))
+fi
+if (( dependency == 4 )); then
+  goals_adjust=$((goals_adjust + 1))
+  phases_adjust=$((phases_adjust + 1))
+fi
+if (( verification == 4 )); then
+  phases_adjust=$((phases_adjust + 1))
+fi
+if (( uncertainty == 0 && dependency == 0 && verification == 0 )); then
+  goals_adjust=$((goals_adjust - 1))
+  phases_adjust=$((phases_adjust - 1))
+fi
+
+base_recommended_goals=$((goals_midpoint + goals_adjust))
+base_recommended_phases=$((phases_midpoint + phases_adjust))
+
+if (( base_recommended_goals < goals_min )); then
+  base_recommended_goals="${goals_min}"
+elif (( base_recommended_goals > goals_max )); then
+  base_recommended_goals="${goals_max}"
+fi
+
+if (( base_recommended_phases < phases_min )); then
+  base_recommended_phases="${phases_min}"
+elif (( base_recommended_phases > phases_max )); then
+  base_recommended_phases="${phases_max}"
+fi
+
+override_goals="$(jq -er '.overrides.goals? // empty' "${INPUT_FILE}" 2>/dev/null || true)"
+override_phases="$(jq -er '.overrides.phases? // empty' "${INPUT_FILE}" 2>/dev/null || true)"
+override_reason="$(jq -er '.overrides.reason? // empty' "${INPUT_FILE}" 2>/dev/null || true)"
+override_reason="$(echo "${override_reason}" | trim_whitespace)"
+
+recommended_goals="${base_recommended_goals}"
+recommended_phases="${base_recommended_phases}"
+goals_override_applied="false"
+phases_override_applied="false"
+
+if [[ -n "${override_goals}" ]]; then
+  if [[ ! "${override_goals}" =~ ^[0-9]+$ ]] || (( 10#${override_goals} < 1 || 10#${override_goals} > 10 )); then
+    echo "ERROR: overrides.goals must be an integer in 1..10"
+    exit 1
+  fi
+  recommended_goals="${override_goals}"
+  goals_override_applied="true"
+fi
+
+if [[ -n "${override_phases}" ]]; then
+  if [[ ! "${override_phases}" =~ ^[0-9]+$ ]] || (( 10#${override_phases} < 2 || 10#${override_phases} > 20 )); then
+    echo "ERROR: overrides.phases must be an integer in 2..20"
+    exit 1
+  fi
+  recommended_phases="${override_phases}"
+  phases_override_applied="true"
+fi
+
+if [[ "${goals_override_applied}" == "true" || "${phases_override_applied}" == "true" ]]; then
+  if ! jq -e '.overrides.reason? | type == "string"' "${INPUT_FILE}" >/dev/null 2>&1; then
+    echo "ERROR: overrides.reason must be a string when overrides.goals or overrides.phases is set"
+    exit 1
+  fi
+  if [[ -z "${override_reason}" ]]; then
+    echo "ERROR: overrides.reason is required when overrides.goals or overrides.phases is set"
+    exit 1
+  fi
+fi
+
+if [[ "${FORMAT_VALUE}" == "shell" ]]; then
+  cat <<EOF
+total_score=${total_score}
+level=${level}
+level_name=${level_name}
+force_l1=${force_l1}
+goals_min=${goals_min}
+goals_max=${goals_max}
+phases_min=${phases_min}
+phases_max=${phases_max}
+goals_midpoint=${goals_midpoint}
+phases_midpoint=${phases_midpoint}
+adjustment=${phases_adjust}
+goals_adjust=${goals_adjust}
+phases_adjust=${phases_adjust}
+base_recommended_goals=${base_recommended_goals}
+base_recommended_phases=${base_recommended_phases}
+recommended_goals=${recommended_goals}
+recommended_phases=${recommended_phases}
+goals_override_applied=${goals_override_applied}
+phases_override_applied=${phases_override_applied}
+EOF
+  exit 0
+fi
+
+if [[ "${FORMAT_VALUE}" == "json" ]]; then
+  jq -n \
+    --argjson total_score "${total_score}" \
+    --arg level "${level}" \
+    --arg level_name "${level_name}" \
+    --arg force_l1 "${force_l1}" \
+    --argjson goals_min "${goals_min}" \
+    --argjson goals_max "${goals_max}" \
+    --argjson phases_min "${phases_min}" \
+    --argjson phases_max "${phases_max}" \
+    --argjson goals_midpoint "${goals_midpoint}" \
+    --argjson phases_midpoint "${phases_midpoint}" \
+    --argjson goals_adjust "${goals_adjust}" \
+    --argjson phases_adjust "${phases_adjust}" \
+    --argjson base_recommended_goals "${base_recommended_goals}" \
+    --argjson base_recommended_phases "${base_recommended_phases}" \
+    --argjson recommended_goals "${recommended_goals}" \
+    --argjson recommended_phases "${recommended_phases}" \
+    --arg goals_override_applied "${goals_override_applied}" \
+    --arg phases_override_applied "${phases_override_applied}" \
+    --arg override_reason "${override_reason}" \
+    '{
+      total_score: $total_score,
+      level: $level,
+      level_name: $level_name,
+      force_l1: ($force_l1 == "true"),
+      ranges: {
+        goals: { min: $goals_min, max: $goals_max },
+        phases: { min: $phases_min, max: $phases_max }
+      },
+      midpoint: {
+        goals: $goals_midpoint,
+        phases: $phases_midpoint
+      },
+      adjustment: $phases_adjust,
+      adjustments: {
+        goals: $goals_adjust,
+        phases: $phases_adjust
+      },
+      base_recommended: {
+        goals: $base_recommended_goals,
+        phases: $base_recommended_phases
+      },
+      recommended: {
+        goals: $recommended_goals,
+        phases: $recommended_phases
+      },
+      override_applied: {
+        goals: ($goals_override_applied == "true"),
+        phases: ($phases_override_applied == "true")
+      },
+      override_reason: (
+        if ($goals_override_applied == "true" or $phases_override_applied == "true")
+        then $override_reason
+        else null
+        end
+      )
+    }'
+  exit 0
+fi
+
+cat <<EOF
+## Complexity Score
+- Total score: ${total_score}
+- Level: ${level} (${level_name})
+- Forced L1 guardrail: ${force_l1}
+
+## Ranges
+- Goals: ${goals_min}-${goals_max}
+- Phases: ${phases_min}-${phases_max}
+
+## Deterministic Recommendation
+- Midpoints: goals=${goals_midpoint}, phases=${phases_midpoint}
+- Adjustments: goals=${goals_adjust}, phases=${phases_adjust}
+- Base recommendation: goals=${base_recommended_goals}, phases=${base_recommended_phases}
+- Final recommendation: goals=${recommended_goals}, phases=${recommended_phases}
+EOF
+
+if [[ "${goals_override_applied}" == "true" || "${phases_override_applied}" == "true" ]]; then
+  cat <<EOF
+
+## Override
+- Applied: true
+- Reason: ${override_reason}
+EOF
+fi

--- a/codex/scripts/goals-next-iteration.sh
+++ b/codex/scripts/goals-next-iteration.sh
@@ -58,7 +58,7 @@ cat > "$NEW_GOALS" <<EOF
 - Iteration: ${NEXT_ITERATION}
 - State: draft
 
-## Goals (0–5)
+## Goals (1-10, verifiable)
 
 ## Non-goals
 

--- a/codex/scripts/goals-scaffold.sh
+++ b/codex/scripts/goals-scaffold.sh
@@ -154,7 +154,7 @@ cat > "$GOALS_FILE" <<EOF
 - Iteration: ${ITERATION}
 - State: draft
 
-## Goals (0–5)
+## Goals (1-10, verifiable)
 
 ## Non-goals
 

--- a/codex/scripts/prepare-phased-impl-validate.sh
+++ b/codex/scripts/prepare-phased-impl-validate.sh
@@ -127,9 +127,11 @@ fi
 
 phase_count=""
 if [[ -f "${PHASE_PLAN_FILE}" ]]; then
-  phase_count="$(sed -n 's/^- Phase count: \([1-4]\)$/\1/p' "${PHASE_PLAN_FILE}" | head -n 1)"
+  phase_count="$(sed -nE 's/^- Phase count:[[:space:]]*([0-9]+)[[:space:]]*$/\1/p' "${PHASE_PLAN_FILE}" | head -n 1)"
   if [[ -z "${phase_count}" ]]; then
-    issues+=("Unable to parse '- Phase count: <1-4>' from ${PHASE_PLAN_FILE}")
+    issues+=("Unable to parse '- Phase count: <2-20>' from ${PHASE_PLAN_FILE}")
+  elif (( 10#${phase_count} < 2 || 10#${phase_count} > 20 )); then
+    issues+=("Invalid phase count '${phase_count}' in ${PHASE_PLAN_FILE}; expected 2-20")
   fi
 fi
 

--- a/codex/skills/complexity-scaling/SKILL.md
+++ b/codex/skills/complexity-scaling/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: complexity-scaling
+description: Score task complexity deterministically and derive bounded goals/phases using enforceable JSON signals.
+---
+
+# SKILL: complexity-scaling
+
+## Purpose
+
+Provide deterministic complexity scoring and bounded recommendations that are resistant to subjective interpretation and easy gaming.
+
+Hard global bounds:
+
+- Goals: `1..10`
+- Phases: `2..20`
+
+Executable implementation:
+
+- `codex/scripts/complexity-score.sh`
+
+## Input Schema
+
+Signals are passed as JSON (see `codex/tasks/_templates/complexity-signals.template.json`).
+
+Required keys:
+
+- `scope`: `0|2|4`
+- `behavior`: `0|2|4`
+- `dependency`: `0|2|4`
+- `uncertainty`: `0|2|4`
+- `verification`: `0|2|4`
+- `evidence.scope`: trimmed non-empty string containing `files=` and `surface=`
+- `evidence.behavior`: trimmed non-empty string
+- `evidence.dependency`: trimmed non-empty string containing `interfaces=` (or `interfaces=none`)
+- `evidence.uncertainty`: trimmed non-empty string
+- `evidence.verification`: trimmed non-empty string containing `checks=`
+- `evidence.guardrails`: trimmed non-empty string
+- `guardrails.no_schema_or_api_contract_change`: boolean
+- `guardrails.no_new_external_dependencies`: boolean
+- `guardrails.localized_surface`: boolean
+- `guardrails.reversible_with_straightforward_verification`: boolean
+
+Optional keys:
+
+- `overrides.goals`: integer `1..10`
+- `overrides.phases`: integer `2..20`
+- `overrides.reason`: required trimmed non-empty string when any override is set
+
+## Signal Rubric (0/2/4 only)
+
+1. Scope:
+- `0`: single file/function
+- `2`: multi-file, one subsystem
+- `4`: cross-domain or cross-service
+
+2. Behavior:
+- `0`: no user-visible change
+- `2`: one workflow change
+- `4`: broad behavior or contract change
+
+3. Dependency:
+- `0`: no interface/dependency changes
+- `2`: one interface/dependency touched
+- `4`: multiple interfaces coordinated
+
+4. Uncertainty:
+- `0`: known implementation pattern
+- `2`: partial ambiguity or migration risk
+- `4`: high ambiguity or failure-sensitive path
+
+5. Verification:
+- `0`: narrow verification in one test area
+- `2`: multi-layer validation required
+- `4`: full lint/build/test plus integration coverage
+
+## Level Mapping
+
+Total score = sum of five signals (`0..20`).
+
+| Level | Score | Goals range | Phases range |
+| --- | --- | --- | --- |
+| L1 `surgical` | `0..4` | `1..2` | `2..3` |
+| L2 `focused` | `5..8` | `2..4` | `3..6` |
+| L3 `multi-surface` | `9..12` | `3..6` | `6..10` |
+| L4 `cross-system` | `13..16` | `5..8` | `10..15` |
+| L5 `program` | `17..20` | `7..10` | `15..20` |
+
+## Forced L1 Rule (Anti-gaming)
+
+Force L1 only when all guardrails are true:
+
+- `no_schema_or_api_contract_change`
+- `no_new_external_dependencies`
+- `localized_surface`
+- `reversible_with_straightforward_verification`
+
+Consistency gate:
+
+- when forced L1 is active, each signal (`scope`, `behavior`, `dependency`, `uncertainty`, `verification`) must be `<=2`
+- if any signal is `4`, the signals file is invalid and must be rejected
+
+## Deterministic Count Formula
+
+1. Midpoint (integer floor):
+- goals midpoint = `floor((goals_min + goals_max)/2)`
+- phases midpoint = `floor((phases_min + phases_max)/2)`
+
+2. Split adjustments:
+- `goals_adjust = (+1 if uncertainty=4) + (+1 if dependency=4) - (1 if uncertainty=0 and dependency=0 and verification=0)`
+- `phases_adjust = (+1 if uncertainty=4) + (+1 if dependency=4) + (+1 if verification=4) - (1 if uncertainty=0 and dependency=0 and verification=0)`
+
+3. Base recommendation:
+- `base_goals = clamp(goals_midpoint + goals_adjust, goals_min, goals_max)`
+- `base_phases = clamp(phases_midpoint + phases_adjust, phases_min, phases_max)`
+
+4. Overrides:
+- if provided, `overrides.goals` and `overrides.phases` replace base recommendations
+- `overrides.reason` is required whenever either override is provided
+- override usage must be surfaced in markdown output with the reason
+- reject overrides outside global bounds
+
+## Guardrail Operational Definitions
+
+- `no_schema_or_api_contract_change`:
+  - no DB migrations/schema changes
+  - no public API signature changes
+  - no message format/config schema changes
+- `no_new_external_dependencies`:
+  - no new external services, packages, or integration points
+- `localized_surface`:
+  - bounded file surface in one subsystem
+  - supported by `evidence.scope` (`files=`, `surface=`)
+- `reversible_with_straightforward_verification`:
+  - rollback is straightforward
+  - validation is bounded and explicit
+  - supported by `evidence.verification` (`checks=`)
+
+## Tie-break and Determinism Rules
+
+- Only `{0,2,4}` scores are valid.
+- Evidence lines are trimmed before validation.
+- Midpoints use integer floor.
+- Adjustment rules above are the only permitted modifiers.
+- No free-form range nudging is allowed outside formula + overrides.
+
+## Commands
+
+Shell output:
+
+```bash
+./codex/scripts/complexity-score.sh ./tasks/<task>/complexity-signals.json --format shell
+```
+
+JSON output:
+
+```bash
+./codex/scripts/complexity-score.sh ./tasks/<task>/complexity-signals.json --format json
+```
+
+Markdown summary:
+
+```bash
+./codex/scripts/complexity-score.sh ./tasks/<task>/complexity-signals.json --format markdown
+```
+
+## Integration
+
+- Stage 3 scaffolding may pass `@<signals-json-path>` to `prepare-phased-impl-scaffold.sh`.
+- Optional Stage 1 validation may pass the same signals file as a third argument to `goals-validate.sh` to enforce level-specific goal ranges.

--- a/codex/skills/establish-goals/SKILL.md
+++ b/codex/skills/establish-goals/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: establish-goals
-description: Clarify an ambiguous or incomplete request and produce 0–5 explicit, verifiable goals before any planning or implementation.
+description: Clarify an ambiguous or incomplete request and produce 1-10 explicit, verifiable goals before any planning or implementation.
 ---
 
 # SKILL: establish-goals
 
 ## Purpose
 
-Execute the `establish-goals` lifecycle stage in isolation to eliminate ambiguity and produce **0–5 verifiable goals** with explicit success criteria.
+Execute the `establish-goals` lifecycle stage in isolation to eliminate ambiguity and produce **1-10 verifiable goals** with explicit success criteria.
 
 This skill establishes the contractual foundation for downstream execution and ends at goal lock.
 
@@ -36,9 +36,17 @@ This skill explicitly excludes:
 
 ---
 
+## Rule dependencies
+
+Goal count should scale with complexity according to:
+
+- `codex/skills/complexity-scaling/SKILL.md`
+
+---
+
 ## Hard stop rule (mandatory)
 
-If an iteration produces **ZERO goals**, execution MUST STOP.
+If an iteration cannot produce **at least one verifiable goal**, execution MUST STOP.
 
 The agent MUST NOT proceed to:
 
@@ -111,6 +119,7 @@ All file creation, iteration, validation, and extraction MUST be performed using
 - `goals-next-iteration.sh`
 - `goals-extract.sh`
 - `goals-validate.sh`
+- `complexity-score.sh` (for deterministic level/range selection when signals are available)
 
 Direct manual file creation or copying is NOT permitted.
 
@@ -175,7 +184,7 @@ Edit `establish-goals.vN.md` to populate:
 - Ambiguities (blocking vs non-blocking)
 - Questions for user (blocking first)
 - Assumptions (explicit; never implicit)
-- Goals (0–5, verifiable)
+- Goals (1-10, verifiable)
 - Non-goals (explicit exclusions)
 - Success criteria (objective, mapped to goals)
 - Risks / tradeoffs
@@ -221,12 +230,16 @@ Validate the iteration using:
 
 `<CODEX_SCRIPTS_DIR>/goals-validate.sh <TASK_NAME_IN_KEBAB_CASE> vN`
 
+Optional complexity-linked validation:
+
+`<CODEX_SCRIPTS_DIR>/goals-validate.sh <TASK_NAME_IN_KEBAB_CASE> vN <path-to-complexity-signals.json>`
+
 This validation enforces:
 
-- goal count ∈ [0,5]
-- zero goals ⇒ State = blocked
+- goal count ∈ [1,10]
 - goals present ⇒ success criteria required
 - locked state consistency
+- when a signals file is provided: goal count must be within the scored level range
 
 Validation failures MUST be resolved before proceeding.
 
@@ -234,7 +247,7 @@ Validation failures MUST be resolved before proceeding.
 
 ### Step 6 — Hard stop enforcement
 
-If goals == 0:
+If at least one verifiable goal cannot be stated:
 
 - State MUST be `blocked`
 - Ask ONLY the blocking clarification questions
@@ -277,7 +290,7 @@ This step completes the `establish-goals` skill.
 
 This skill is complete ONLY when:
 
-- goals exist (1–5)
+- goals exist (1-10)
 - goals are verifiable
 - State = `locked`
 - validation passes

--- a/codex/skills/prepare-phased-impl/SKILL.md
+++ b/codex/skills/prepare-phased-impl/SKILL.md
@@ -24,6 +24,7 @@ Stage 3 depends on the same rule files as Stage 2:
 
 - `codex/rules/expand-task-spec.rules`
 - `codex/rules/git-safe.rules`
+- `codex/skills/complexity-scaling/SKILL.md`
 
 ## Approved scripts (mandatory)
 
@@ -33,6 +34,7 @@ All Stage 3 setup/locking/validation operations MUST run through:
 - `prepare-phased-impl-scaffold.sh`
 - `prepare-phased-impl-scope-lock.sh`
 - `prepare-phased-impl-validate.sh`
+- `complexity-score.sh` (when deriving complexity from scored signals JSON)
 
 Direct shell reimplementation of these operations is not allowed.
 
@@ -56,10 +58,14 @@ Fallback order:
 
 - Confirm `<TASK_NAME_IN_KEBAB_CASE>`.
 - Select one complexity value:
-  - `simple`
-  - `medium`
-  - `complex`
-  - `1|2|3|4` (explicit phase count override)
+  - `surgical`
+  - `focused`
+  - `multi-surface`
+  - `cross-system`
+  - `program`
+  - compatibility labels: `simple|medium|complex|very-complex`
+  - explicit phase count override: `2..20`
+  - deterministic scored input: `@<path-to-complexity-signals.json>`
 
 Complexity drives phase count dynamically.
 
@@ -93,16 +99,21 @@ This writes `./tasks/<TASK_NAME_IN_KEBAB_CASE>/.scope-lock.md` from `spec.md` sc
 Run:
 
 ```bash
-<CODEX_SCRIPTS_DIR>/prepare-phased-impl-scaffold.sh <TASK_NAME_IN_KEBAB_CASE> <simple|medium|complex|1|2|3|4>
+<CODEX_SCRIPTS_DIR>/prepare-phased-impl-scaffold.sh <TASK_NAME_IN_KEBAB_CASE> <complexity-label|2..20>
+```
+
+or (deterministic scored input):
+
+```bash
+<CODEX_SCRIPTS_DIR>/prepare-phased-impl-scaffold.sh <TASK_NAME_IN_KEBAB_CASE> @<path-to-complexity-signals.json>
 ```
 
 Script behavior:
 
 - enforces hard precondition: `spec.md` must contain `READY FOR PLANNING`
-- maps complexity to phase count:
-  - `simple` -> 2
-  - `medium` -> 3
-  - `complex` -> 4
+- maps complexity labels to default phase counts within the policy ranges in `codex/skills/complexity-scaling/SKILL.md`
+- accepts explicit phase count override only in `2..20`
+- when provided a scored input file (`@...`), derives phase count using `complexity-score.sh`
 - creates missing `phase-<n>.md` files for active phases
 - writes `./tasks/<TASK_NAME_IN_KEBAB_CASE>/phase-plan.md` with `PENDING` verdict
 - initializes/advances `./tasks/<TASK_NAME_IN_KEBAB_CASE>/lifecycle-state.md` Stage 3 cycle metadata

--- a/codex/tasks/_templates/complexity-signals.template.json
+++ b/codex/tasks/_templates/complexity-signals.template.json
@@ -1,0 +1,24 @@
+{
+  "scope": 0,
+  "behavior": 0,
+  "dependency": 0,
+  "uncertainty": 0,
+  "verification": 0,
+  "evidence": {
+    "scope": "files=3 surface=tasks+scripts bounded to one subsystem",
+    "behavior": "one workflow updated; no broad behavior contract changes",
+    "dependency": "interfaces=none",
+    "uncertainty": "known pattern with small migration risk",
+    "verification": "checks=lint,build,test",
+    "guardrails": "no schema/api contract change; no new deps; localized surface; reversible with straightforward verification"
+  },
+  "guardrails": {
+    "no_schema_or_api_contract_change": true,
+    "no_new_external_dependencies": true,
+    "localized_surface": true,
+    "reversible_with_straightforward_verification": true
+  },
+  "overrides": {
+    "reason": ""
+  }
+}


### PR DESCRIPTION
## Summary
- expand establish-goals limits from 0-5 to 1-10 and update prompts/templates/checklists
- add deterministic complexity scoring via codex/scripts/complexity-score.sh and a signals template
- update Stage 3 scaffolding/validation to support scaled phase counts and scored inputs