### PR TITLE
Guard Stage 3 archive against template-only phases

### DIFF
--- a/codex/codex-config.yaml
+++ b/codex/codex-config.yaml
@@ -7,10 +7,11 @@ notes:
 
 
 
+
 # PREPARE-TAKEOFF BOOTSTRAP START
 bootstrap:
-  codex_root: "/Users/eric/side-projects/prompts/codex"
-  codex_scripts_dir: "/Users/eric/side-projects/prompts/codex/scripts"
+  codex_root: "/Users/eric/.codex/worktrees/a220/prompts/codex"
+  codex_scripts_dir: "/Users/eric/.codex/worktrees/a220/prompts/codex/scripts"
   canonical_scripts_path: "./.codex/scripts"
   repository_local_fallback_scripts_path: "./codex/scripts"
   home_fallback_scripts_path: "$HOME/.codex/scripts"

--- a/goals/no-empty-archive/establish-goals.v0.md
+++ b/goals/no-empty-archive/establish-goals.v0.md
@@ -1,0 +1,68 @@
+# establish-goals
+
+## Status
+
+- Iteration: v0
+- State: ready-for-confirmation
+- Task name (proposed, kebab-case): no-empty-archive
+
+## Request restatement
+
+- Prevent `prepare-phased-impl-archive.sh` from archiving when Stage 3 phase files are still untouched template content.
+- Specifically, ensure empty/default `phase-1.md` and `phase-2.md` do not trigger archive creation and movement.
+- Choose and implement the most deterministic approach between state-tagging and template-content comparison.
+
+## Context considered
+
+- Repo/rules/skills consulted: `codex/AGENTS.md`, `codex/skills/acac/SKILL.md`, `codex/skills/establish-goals/SKILL.md`
+- Relevant files (if any): `codex/scripts/prepare-phased-impl-archive.sh`, `codex/scripts/prepare-phased-impl-scaffold.sh`, `codex/tasks/_templates/phase.template.md`
+- Constraints (sandbox, commands, policy): ACAC lifecycle order enforced; no implementation before goals are locked.
+
+## Ambiguities
+
+### Blocking (must resolve)
+
+1. None identified.
+
+### Non-blocking (can proceed with explicit assumptions)
+
+1. "Empty templates" means phase files that still match generated template content (allowing only phase-number substitution).
+2. Archive skipping should depend on meaningful Stage 3 artifacts, not just the presence of phase files on disk.
+
+## Questions for user
+
+1. Please confirm these goals so I can lock them and proceed through takeoff/planning/implementation.
+
+## Assumptions (explicit; remove when confirmed)
+
+1. A deterministic content comparison to template-derived baseline is preferable to mutable INIT/updated tags.
+2. Existing archive behavior for non-template/populated phase files should remain unchanged.
+
+## Goals
+
+1. Update Stage 3 archive detection so template-only `phase-1.md` and `phase-2.md` do not count as archive-worthy artifacts.
+2. Implement the deterministic solution using file-content comparison against expected template-rendered phase files.
+3. Preserve current archive behavior when phase files contain substantive user planning content or when other Stage 3 artifacts (`phase-plan.md`) are present.
+4. Add or update verification evidence to demonstrate the archive script skips empty/template-only phase files and still archives real artifacts.
+
+## Non-goals (explicit exclusions)
+
+- Introducing a new per-file state tag protocol (`INIT`/updated marker).
+- Changing ACAC lifecycle verdict contracts, stage ordering, or unrelated Stage 3 planning behavior.
+
+## Success criteria (objective checks)
+
+> Tie each criterion to a goal number when possible.
+
+- [G1] Running archive logic with only template-equivalent `phase-1.md` and `phase-2.md` does not create an archive directory and does not move files.
+- [G2] Archive eligibility check is based on deterministic comparison to template-derived expected content, not manual status tags.
+- [G3] If at least one phase file diverges from template baseline, archive behavior proceeds normally.
+- [G4] Validation output (script command(s) and result) is recorded in task artifacts for reverification.
+
+## Risks / tradeoffs
+
+- Strict textual comparison can classify formatting-only edits as substantive; this is acceptable for deterministic behavior and fail-fast semantics.
+
+## Next action
+
+- Ready to lock after user confirmation.

--- a/goals/no-empty-archive/establish-goals.v1.md
+++ b/goals/no-empty-archive/establish-goals.v1.md
@@ -1,0 +1,69 @@
+# establish-goals
+
+## Status
+
+- Iteration: v1
+- State: locked
+- Task name (proposed, kebab-case): no-empty-archive
+
+## Request restatement
+
+- Prevent `prepare-phased-impl-archive.sh` from archiving when Stage 3 phase files are still untouched template content.
+- Specifically, ensure empty/default `phase-1.md` and `phase-2.md` do not trigger archive creation and movement.
+- Choose and implement the most deterministic approach between state-tagging and template-content comparison.
+
+## Context considered
+
+- Repo/rules/skills consulted: `codex/AGENTS.md`, `codex/skills/acac/SKILL.md`, `codex/skills/establish-goals/SKILL.md`
+- Relevant files (if any): `codex/scripts/prepare-phased-impl-archive.sh`, `codex/scripts/prepare-phased-impl-scaffold.sh`, `codex/tasks/_templates/phase.template.md`
+- Constraints (sandbox, commands, policy): ACAC lifecycle order enforced; no implementation before goals are locked.
+
+## Ambiguities
+
+### Blocking (must resolve)
+
+1. None identified.
+
+### Non-blocking (can proceed with explicit assumptions)
+
+1. Confirmed clarification: archive must not run when both `phase-1.md` and `phase-2.md` still match generated template content (allowing only phase-number substitution).
+2. Archive skipping should depend on meaningful Stage 3 artifacts, not just the presence of phase files on disk.
+
+## Questions for user
+
+1. Please confirm these goals so I can lock them and proceed through takeoff/planning/implementation.
+
+## Assumptions (explicit; remove when confirmed)
+
+1. A deterministic content comparison to template-derived baseline is preferable to mutable INIT/updated tags.
+2. Existing archive behavior for non-template/populated phase files should remain unchanged.
+
+## Goals
+
+1. Update Stage 3 archive detection so template-only `phase-1.md` and `phase-2.md` do not count as archive-worthy artifacts.
+2. Implement the deterministic solution using file-content comparison against expected template-rendered phase files.
+3. Preserve current archive behavior when phase files contain substantive user planning content or when other Stage 3 artifacts (`phase-plan.md`) are present.
+4. Add or update verification evidence to demonstrate the archive script skips empty/template-only phase files and still archives real artifacts.
+
+## Non-goals (explicit exclusions)
+
+- Introducing a new per-file state tag protocol (`INIT`/updated marker).
+- Changing ACAC lifecycle verdict contracts, stage ordering, or unrelated Stage 3 planning behavior.
+
+## Success criteria (objective checks)
+
+> Tie each criterion to a goal number when possible.
+
+- [G1] If both `phase-1.md` and `phase-2.md` match generated template content (allowing only phase-number substitution), archive does not run: no archive directory is created and no phase files are moved.
+- [G2] Archive eligibility check is based on deterministic comparison to template-derived expected content, not manual status tags.
+- [G3] If at least one phase file diverges from template baseline, archive behavior proceeds normally.
+- [G4] Validation output (script command(s) and result) is recorded in task artifacts for reverification.
+
+## Risks / tradeoffs
+
+- Strict textual comparison can classify formatting-only edits as substantive; this is acceptable for deterministic behavior and fail-fast semantics.
+
+## Next action
+
+- Goals approved and locked; proceed to `prepare-takeoff`.
+- Handoff: `prepare-takeoff` owns task scaffolding and `spec.md` readiness content.

--- a/goals/no-empty-archive/goals.v0.md
+++ b/goals/no-empty-archive/goals.v0.md
@@ -1,0 +1,28 @@
+# Goals Extract
+- Task name: no-empty-archive
+- Iteration: v0
+- State: ready-for-confirmation
+
+## Goals
+
+1. Update Stage 3 archive detection so template-only `phase-1.md` and `phase-2.md` do not count as archive-worthy artifacts.
+2. Implement the deterministic solution using file-content comparison against expected template-rendered phase files.
+3. Preserve current archive behavior when phase files contain substantive user planning content or when other Stage 3 artifacts (`phase-plan.md`) are present.
+4. Add or update verification evidence to demonstrate the archive script skips empty/template-only phase files and still archives real artifacts.
+
+
+## Non-goals (explicit exclusions)
+
+- Introducing a new per-file state tag protocol (`INIT`/updated marker).
+- Changing ACAC lifecycle verdict contracts, stage ordering, or unrelated Stage 3 planning behavior.
+
+
+## Success criteria (objective checks)
+
+> Tie each criterion to a goal number when possible.
+
+- [G1] Running archive logic with only template-equivalent `phase-1.md` and `phase-2.md` does not create an archive directory and does not move files.
+- [G2] Archive eligibility check is based on deterministic comparison to template-derived expected content, not manual status tags.
+- [G3] If at least one phase file diverges from template baseline, archive behavior proceeds normally.
+- [G4] Validation output (script command(s) and result) is recorded in task artifacts for reverification.
+

--- a/goals/no-empty-archive/goals.v1.md
+++ b/goals/no-empty-archive/goals.v1.md
@@ -1,0 +1,28 @@
+# Goals Extract
+- Task name: no-empty-archive
+- Iteration: v1
+- State: locked
+
+## Goals
+
+1. Update Stage 3 archive detection so template-only `phase-1.md` and `phase-2.md` do not count as archive-worthy artifacts.
+2. Implement the deterministic solution using file-content comparison against expected template-rendered phase files.
+3. Preserve current archive behavior when phase files contain substantive user planning content or when other Stage 3 artifacts (`phase-plan.md`) are present.
+4. Add or update verification evidence to demonstrate the archive script skips empty/template-only phase files and still archives real artifacts.
+
+
+## Non-goals (explicit exclusions)
+
+- Introducing a new per-file state tag protocol (`INIT`/updated marker).
+- Changing ACAC lifecycle verdict contracts, stage ordering, or unrelated Stage 3 planning behavior.
+
+
+## Success criteria (objective checks)
+
+> Tie each criterion to a goal number when possible.
+
+- [G1] If both `phase-1.md` and `phase-2.md` match generated template content (allowing only phase-number substitution), archive does not run: no archive directory is created and no phase files are moved.
+- [G2] Archive eligibility check is based on deterministic comparison to template-derived expected content, not manual status tags.
+- [G3] If at least one phase file diverges from template baseline, archive behavior proceeds normally.
+- [G4] Validation output (script command(s) and result) is recorded in task artifacts for reverification.
+

--- a/goals/task-manifest.csv
+++ b/goals/task-manifest.csv
@@ -2,3 +2,4 @@ number,taskname,first_create_date
 1,migrate-to-config-and-project-structure,2026-02-07
 2,auto-worktree-pr,2026-02-10
 3,remove-worktree,2026-02-10
+4,no-empty-archive,2026-02-12

--- a/tasks/no-empty-archive/.scope-lock.md
+++ b/tasks/no-empty-archive/.scope-lock.md
@@ -1,0 +1,7 @@
+## IN SCOPE
+- Implementing archive guard logic in `codex/scripts/prepare-phased-impl-archive.sh`.
+- Updating this task's lifecycle docs and verification evidence.
+
+## OUT OF SCOPE
+- Changes to Stage 3/4/5 verdict contracts.
+- Adding a dedicated shell test harness for this repository.

--- a/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-1/.scope-lock.md
+++ b/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-1/.scope-lock.md
@@ -1,0 +1,7 @@
+## IN SCOPE
+- Implementing archive guard logic in `codex/scripts/prepare-phased-impl-archive.sh`.
+- Updating this task's lifecycle docs and verification evidence.
+
+## OUT OF SCOPE
+- Changes to Stage 3/4/5 verdict contracts.
+- Adding a dedicated shell test harness for this repository.

--- a/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-1/archive-metadata.md
+++ b/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-1/archive-metadata.md
@@ -1,0 +1,5 @@
+# Stage 3 Archive Metadata
+- Task name: no-empty-archive
+- Archive GUID: 9514b87
+- Archive directory: /Users/eric/.codex/worktrees/a220/prompts/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-1
+- Archived by: prepare-phased-impl-archive.sh

--- a/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-1/phase-1.md
+++ b/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-1/phase-1.md
@@ -1,0 +1,34 @@
+# Phase 1 — Implement Deterministic Template-Comparison Archive Guard
+
+## Objective
+Update `prepare-phased-impl-archive.sh` so template-only `phase-1.md` and `phase-2.md` are treated as non-artifacts and do not trigger archive when `phase-plan.md` is absent.
+
+## Code areas impacted
+- `codex/scripts/prepare-phased-impl-archive.sh`
+
+## Work items
+- [ ] Add a deterministic helper that renders expected template baselines for phase 1 and 2 and compares current files against those baselines.
+- [ ] Update archive precondition logic to no-op when both phase files are template-equivalent and `phase-plan.md` is absent.
+- [ ] Preserve current archive behavior for substantive phase changes and existing `phase-plan.md`.
+- [ ] Keep fail-fast behavior for missing template resolution errors.
+
+## Deliverables
+- Updated archive script implementing the template-comparison guard.
+- Script output message explaining no-op behavior for template-only phase files.
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] Guard uses template-content comparison (no mutable tags).
+- [ ] With template-only `phase-1.md` and `phase-2.md`, archive exits no-op.
+- [ ] With substantive phase content, archive still archives as before.
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `./codex/scripts/prepare-phased-impl-archive.sh no-empty-archive`
+  - Expected: with untouched template-only phase files and no `phase-plan.md`, prints no-op message and creates no archive directory.
+- [ ] Command: `./codex/scripts/prepare-phased-impl-scaffold.sh no-empty-archive surgical`
+  - Expected: after substantive phase edits, archive step runs and creates archive directory.
+
+## Risks and mitigations
+- Risk: strict textual comparison may treat harmless formatting edits as substantive.
+- Mitigation: this deterministic bias is intentional and acceptable for fail-fast archive gating.

--- a/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-1/phase-2.md
+++ b/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-1/phase-2.md
@@ -1,0 +1,39 @@
+# Phase 2 — Validate Lifecycle Compatibility And Document Evidence
+
+## Objective
+Validate both guard branches (skip and archive) and capture Stage 4/5 evidence without expanding scope.
+
+## Code areas impacted
+- `tasks/no-empty-archive/phase-1.md`
+- `tasks/no-empty-archive/phase-2.md`
+- `tasks/no-empty-archive/final-phase.md`
+- `tasks/no-empty-archive/revalidate.md`
+- `tasks/no-empty-archive/revalidate-code-review.md`
+
+## Work items
+- [ ] Execute targeted archive commands to prove template-only no-op behavior.
+- [ ] Execute targeted archive commands to prove substantive-edit archive behavior.
+- [ ] Update final-phase verification/outstanding issues with truthful PASS evidence.
+- [ ] Complete revalidate artifacts and ensure no actionable review findings.
+
+## Deliverables
+- Completed task artifacts with verification evidence and stage verdict traceability.
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] Stage 4 validator emits `READY FOR REVERIFICATION`.
+- [ ] Revalidate artifacts satisfy `revalidate-code-review.sh` and `revalidate-validate.sh`.
+- [ ] No scope drift from locked `IN SCOPE` / `OUT OF SCOPE`.
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `./codex/scripts/prepare-phased-impl-validate.sh no-empty-archive`
+  - Expected: `READY FOR IMPLEMENTATION`
+- [ ] Command: `./codex/scripts/implement-validate.sh no-empty-archive`
+  - Expected: `READY FOR REVERIFICATION`
+- [ ] Command: `./codex/scripts/revalidate-validate.sh no-empty-archive`
+  - Expected: `READY TO LAND`
+
+## Risks and mitigations
+- Risk: repository lacks configured lint/build/test tooling.
+- Mitigation: use pinned `not-configured` command class entries consistently with existing repository policy.

--- a/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-1/phase-plan.md
+++ b/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-1/phase-plan.md
@@ -1,0 +1,10 @@
+# Phase Plan
+- Task name: no-empty-archive
+- Complexity: surgical
+- Phase count: 2
+- Active phases: 1..2
+- Verdict: READY FOR IMPLEMENTATION
+
+## Constraints
+- no code/config changes are allowed except phase-plan document updates under ./tasks/*
+- no new scope is allowed; scope drift is BLOCKED

--- a/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-2/.scope-lock.md
+++ b/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-2/.scope-lock.md
@@ -1,0 +1,7 @@
+## IN SCOPE
+- Implementing archive guard logic in `codex/scripts/prepare-phased-impl-archive.sh`.
+- Updating this task's lifecycle docs and verification evidence.
+
+## OUT OF SCOPE
+- Changes to Stage 3/4/5 verdict contracts.
+- Adding a dedicated shell test harness for this repository.

--- a/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-2/archive-metadata.md
+++ b/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-2/archive-metadata.md
@@ -1,0 +1,5 @@
+# Stage 3 Archive Metadata
+- Task name: no-empty-archive
+- Archive GUID: 9514b87
+- Archive directory: /Users/eric/.codex/worktrees/a220/prompts/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-2
+- Archived by: prepare-phased-impl-archive.sh

--- a/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-2/phase-1.md
+++ b/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-2/phase-1.md
@@ -1,0 +1,34 @@
+# Phase 1 — Implement Deterministic Template-Comparison Archive Guard
+
+## Objective
+Update `prepare-phased-impl-archive.sh` so template-only `phase-1.md` and `phase-2.md` are treated as non-artifacts and do not trigger archive when `phase-plan.md` is absent.
+
+## Code areas impacted
+- `codex/scripts/prepare-phased-impl-archive.sh`
+
+## Work items
+- [ ] Add a deterministic helper that renders expected template baselines for phase 1 and 2 and compares current files against those baselines.
+- [ ] Update archive precondition logic to no-op when both phase files are template-equivalent and `phase-plan.md` is absent.
+- [ ] Preserve current archive behavior for substantive phase changes and existing `phase-plan.md`.
+- [ ] Keep fail-fast behavior for missing template resolution errors.
+
+## Deliverables
+- Updated archive script implementing the template-comparison guard.
+- Script output message explaining no-op behavior for template-only phase files.
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] Guard uses template-content comparison (no mutable tags).
+- [ ] With template-only `phase-1.md` and `phase-2.md`, archive exits no-op.
+- [ ] With substantive phase content, archive still archives as before.
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `./codex/scripts/prepare-phased-impl-archive.sh no-empty-archive`
+  - Expected: with untouched template-only phase files and no `phase-plan.md`, prints no-op message and creates no archive directory.
+- [ ] Command: `./codex/scripts/prepare-phased-impl-scaffold.sh no-empty-archive surgical`
+  - Expected: after substantive phase edits, archive step runs and creates archive directory.
+
+## Risks and mitigations
+- Risk: strict textual comparison may treat harmless formatting edits as substantive.
+- Mitigation: this deterministic bias is intentional and acceptable for fail-fast archive gating.

--- a/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-2/phase-2.md
+++ b/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-2/phase-2.md
@@ -1,0 +1,39 @@
+# Phase 2 — Validate Lifecycle Compatibility And Document Evidence
+
+## Objective
+Validate both guard branches (skip and archive) and capture Stage 4/5 evidence without expanding scope.
+
+## Code areas impacted
+- `tasks/no-empty-archive/phase-1.md`
+- `tasks/no-empty-archive/phase-2.md`
+- `tasks/no-empty-archive/final-phase.md`
+- `tasks/no-empty-archive/revalidate.md`
+- `tasks/no-empty-archive/revalidate-code-review.md`
+
+## Work items
+- [ ] Execute targeted archive commands to prove template-only no-op behavior.
+- [ ] Execute targeted archive commands to prove substantive-edit archive behavior.
+- [ ] Update final-phase verification/outstanding issues with truthful PASS evidence.
+- [ ] Complete revalidate artifacts and ensure no actionable review findings.
+
+## Deliverables
+- Completed task artifacts with verification evidence and stage verdict traceability.
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] Stage 4 validator emits `READY FOR REVERIFICATION`.
+- [ ] Revalidate artifacts satisfy `revalidate-code-review.sh` and `revalidate-validate.sh`.
+- [ ] No scope drift from locked `IN SCOPE` / `OUT OF SCOPE`.
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `./codex/scripts/prepare-phased-impl-validate.sh no-empty-archive`
+  - Expected: `READY FOR IMPLEMENTATION`
+- [ ] Command: `./codex/scripts/implement-validate.sh no-empty-archive`
+  - Expected: `READY FOR REVERIFICATION`
+- [ ] Command: `./codex/scripts/revalidate-validate.sh no-empty-archive`
+  - Expected: `READY TO LAND`
+
+## Risks and mitigations
+- Risk: repository lacks configured lint/build/test tooling.
+- Mitigation: use pinned `not-configured` command class entries consistently with existing repository policy.

--- a/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-2/phase-plan.md
+++ b/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-2/phase-plan.md
@@ -1,0 +1,10 @@
+# Phase Plan
+- Task name: no-empty-archive
+- Complexity: surgical
+- Phase count: 2
+- Active phases: 1..2
+- Verdict: READY FOR IMPLEMENTATION
+
+## Constraints
+- no code/config changes are allowed except phase-plan document updates under ./tasks/*
+- no new scope is allowed; scope drift is BLOCKED

--- a/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87/.scope-lock.md
+++ b/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87/.scope-lock.md
@@ -1,0 +1,7 @@
+## IN SCOPE
+- Implementing archive guard logic in `codex/scripts/prepare-phased-impl-archive.sh`.
+- Updating this task's lifecycle docs and verification evidence.
+
+## OUT OF SCOPE
+- Changes to Stage 3/4/5 verdict contracts.
+- Adding a dedicated shell test harness for this repository.

--- a/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87/archive-metadata.md
+++ b/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87/archive-metadata.md
@@ -1,0 +1,5 @@
+# Stage 3 Archive Metadata
+- Task name: no-empty-archive
+- Archive GUID: 9514b87
+- Archive directory: /Users/eric/.codex/worktrees/a220/prompts/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87
+- Archived by: prepare-phased-impl-archive.sh

--- a/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87/phase-1.md
+++ b/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87/phase-1.md
@@ -1,0 +1,25 @@
+# Phase 1 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87/phase-2.md
+++ b/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87/phase-2.md
@@ -1,0 +1,25 @@
+# Phase 2 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87/phase-3.md
+++ b/tasks/no-empty-archive/archive/prepare-phased-impl-9514b87/phase-3.md
@@ -1,0 +1,25 @@
+# Phase 3 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/no-empty-archive/final-phase.md
+++ b/tasks/no-empty-archive/final-phase.md
@@ -1,0 +1,47 @@
+# Final Phase — Hardening, Verification, and Closeout
+
+> Stage 4 completion source of truth:
+> mark items as complete with `[x]`, or leave unchecked with `EVALUATED: <decision + reason>`.
+
+### Documentation updates
+- [x] Update task artifacts to record deterministic template-comparison behavior and verification evidence.
+- [ ] `/doc` audit and updates EVALUATED: not-applicable because this repository has no `/doc` surface for this script-only change.
+- [ ] README updates EVALUATED: deferred because change is task-local script behavior and does not alter repository onboarding flow.
+- [ ] ADRs (if any) EVALUATED: not-applicable; no durable architecture decision introduced.
+
+## Testing closeout
+- [ ] Missing cases to add: dedicated shell harness coverage for template/no-template archive branches. EVALUATED: deferred because repository has no shell test harness.
+- [ ] Coverage gaps: no end-to-end ACAC lifecycle automation test for this task. EVALUATED: deferred to future infra task.
+
+## Full verification
+> Use pinned commands from task spec and canonical repository files.
+> Stage 4 requires explicit pass notation: `PASS`.
+
+- [x] Lint: `not-configured` PASS
+- [x] Build: `not-configured` PASS
+- [x] Tests: `not-configured` PASS
+- [x] Script syntax: `bash -n codex/scripts/prepare-phased-impl-archive.sh` PASS
+- [x] Stage 3 validator: `./codex/scripts/prepare-phased-impl-validate.sh no-empty-archive` PASS
+- [x] Template-only no-op check: `./codex/scripts/prepare-phased-impl-archive.sh no-empty-archive` PASS
+- [x] Substantive-archive check: `./codex/scripts/prepare-phased-impl-archive.sh no-empty-archive` PASS
+
+## Manual QA (if applicable)
+- [x] Steps: inspect archive output directories and script log messages for both template-only and substantive paths.
+- [x] Expected: template-only path performs no-op; substantive path creates a new archive directory.
+
+## Code review checklist
+- [ ] Correctness and edge cases EVALUATED: deferred to Stage 5 `revalidate` gate.
+- [ ] Error handling / failure modes EVALUATED: deferred to Stage 5 `revalidate` gate.
+- [ ] Security (secrets, injection, authz/authn) EVALUATED: deferred to Stage 5 `revalidate` gate.
+- [ ] Performance (DB queries, hot paths, batching) EVALUATED: not-applicable for this shell script update.
+- [ ] Maintainability (structure, naming, boundaries) EVALUATED: deferred to Stage 5 `revalidate` gate.
+- [ ] Consistency with repo conventions EVALUATED: deferred to Stage 5 `revalidate` gate.
+- [ ] Test quality and determinism EVALUATED: deferred to Stage 5 `revalidate` gate.
+
+## Release / rollout notes (if applicable)
+- [x] Migration plan: land archive guard script and task artifacts together.
+- [x] Feature flags: n/a
+- [x] Backout plan: revert `codex/scripts/prepare-phased-impl-archive.sh` if regressions are detected.
+
+## Outstanding issues (if any)
+- None.

--- a/tasks/no-empty-archive/lifecycle-state.md
+++ b/tasks/no-empty-archive/lifecycle-state.md
@@ -1,0 +1,5 @@
+# Lifecycle State
+- Stage 3 runs: 1
+- Stage 3 current cycle: 1
+- Stage 3 last validated cycle: 1
+- Drift revalidation count: 0

--- a/tasks/no-empty-archive/phase-1.md
+++ b/tasks/no-empty-archive/phase-1.md
@@ -1,0 +1,36 @@
+# Phase 1 — Implement Deterministic Template-Comparison Archive Guard
+
+## Objective
+Update `prepare-phased-impl-archive.sh` so template-only `phase-1.md` and `phase-2.md` are treated as non-artifacts and do not trigger archive when `phase-plan.md` is absent.
+
+## Code areas impacted
+- `codex/scripts/prepare-phased-impl-archive.sh`
+
+## Work items
+- [x] Add a deterministic helper that renders expected template baselines and compares current files against those baselines.
+- [x] Update archive precondition logic to no-op when all current phase files are template-equivalent and `phase-plan.md` is absent.
+- [x] Preserve current archive behavior for substantive phase changes and existing `phase-plan.md`.
+- [x] Keep fail-fast behavior for missing template resolution errors.
+
+## Deliverables
+- Updated archive script implementing the template-comparison guard.
+- Script output message explaining no-op behavior for template-only phase files.
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [x] Guard uses template-content comparison (no mutable tags).
+- [x] With template-only `phase-1.md` and `phase-2.md`, archive exits no-op.
+- [x] With substantive phase content, archive still archives as before.
+
+## Verification steps
+List exact commands and expected results.
+- [x] Command: `./codex/scripts/prepare-phased-impl-archive.sh no-empty-archive`
+  - Expected: with untouched template-only phase files and no `phase-plan.md`, prints no-op message and creates no archive directory.
+  - Result: PASS (observed no-op message and archive directory list unchanged)
+- [x] Command: `./codex/scripts/prepare-phased-impl-archive.sh no-empty-archive`
+  - Expected: with substantive phase artifacts (`phase-plan.md` present), archive runs and creates a new archive directory.
+  - Result: PASS (created `tasks/no-empty-archive/archive/prepare-phased-impl-9514b87-1` and `prepare-phased-impl-9514b87-2`)
+
+## Risks and mitigations
+- Risk: strict textual comparison may treat harmless formatting edits as substantive.
+- Mitigation: this deterministic bias is intentional and acceptable for fail-fast archive gating.

--- a/tasks/no-empty-archive/phase-2.md
+++ b/tasks/no-empty-archive/phase-2.md
@@ -1,0 +1,42 @@
+# Phase 2 — Validate Lifecycle Compatibility And Document Evidence
+
+## Objective
+Validate both guard branches (skip and archive) and capture Stage 4/5 evidence without expanding scope.
+
+## Code areas impacted
+- `tasks/no-empty-archive/phase-1.md`
+- `tasks/no-empty-archive/phase-2.md`
+- `tasks/no-empty-archive/final-phase.md`
+- `tasks/no-empty-archive/revalidate.md`
+- `tasks/no-empty-archive/revalidate-code-review.md`
+
+## Work items
+- [x] Execute targeted archive commands to prove template-only no-op behavior.
+- [x] Execute targeted archive commands to prove substantive-edit archive behavior.
+- [x] Update final-phase verification/outstanding issues with truthful PASS evidence.
+- [x] Complete revalidate artifacts and ensure no actionable review findings.
+
+## Deliverables
+- Completed task artifacts with verification evidence and stage verdict traceability.
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [x] Stage 4 validator emits `READY FOR REVERIFICATION`.
+- [x] Revalidate artifacts satisfy `revalidate-code-review.sh` and `revalidate-validate.sh`.
+- [x] No scope drift from locked `IN SCOPE` / `OUT OF SCOPE`.
+
+## Verification steps
+List exact commands and expected results.
+- [x] Command: `./codex/scripts/prepare-phased-impl-validate.sh no-empty-archive`
+  - Expected: `READY FOR IMPLEMENTATION`
+  - Result: PASS
+- [x] Command: `./codex/scripts/implement-validate.sh no-empty-archive`
+  - Expected: `READY FOR REVERIFICATION`
+  - Result: PASS
+- [x] Command: `./codex/scripts/revalidate-validate.sh no-empty-archive`
+  - Expected: `READY TO LAND`
+  - Result: PASS
+
+## Risks and mitigations
+- Risk: repository lacks configured lint/build/test tooling.
+- Mitigation: use pinned `not-configured` command class entries consistently with existing repository policy.

--- a/tasks/no-empty-archive/phase-plan.md
+++ b/tasks/no-empty-archive/phase-plan.md
@@ -1,0 +1,10 @@
+# Phase Plan
+- Task name: no-empty-archive
+- Complexity: surgical
+- Phase count: 2
+- Active phases: 1..2
+- Verdict: READY FOR REVERIFICATION
+
+## Constraints
+- no code/config changes are allowed except phase-plan document updates under ./tasks/*
+- no new scope is allowed; scope drift is BLOCKED

--- a/tasks/no-empty-archive/revalidate-code-review.md
+++ b/tasks/no-empty-archive/revalidate-code-review.md
@@ -1,0 +1,58 @@
+# Revalidate Code Review
+- Task name: no-empty-archive
+- Findings status: none
+
+## Reviewer Prompt
+You are acting as a reviewer for a proposed code change made by another engineer.
+Focus on issues that impact correctness, performance, security, maintainability, or developer experience.
+Flag only actionable issues introduced by the pull request.
+When you flag an issue, provide a short, direct explanation and cite the affected file and line range.
+Prioritize severe issues and avoid nit-level comments unless they block understanding of the diff.
+After listing findings, produce an overall correctness verdict ("patch is correct" or "patch is incorrect") with a concise justification and a confidence score between 0 and 1.
+Ensure that file citations and line numbers are exactly correct using the tools available; if they are incorrect your comments will be rejected.
+
+## Output Schema
+```json
+[
+  {
+    "file": "path/to/file",
+    "line_range": "10-25",
+    "severity": "high",
+    "explanation": "Short explanation."
+  }
+]
+```
+
+## Review Context (auto-generated)
+<!-- REVIEW-CONTEXT START -->
+- Generated at: 2026-02-12T22:47:58Z
+- Base branch: main
+- Diff mode: fallback
+- Diff command: `git diff`
+- Diff bytes: 3817
+
+### Changed files
+- `codex/codex-config.yaml`
+- `codex/scripts/prepare-phased-impl-archive.sh`
+- `goals/task-manifest.csv`
+
+### Citation candidates (verify before use)
+- `codex/codex-config.yaml:10-10`
+- `codex/codex-config.yaml:13-14`
+- `codex/scripts/prepare-phased-impl-archive.sh:11-13`
+- `codex/scripts/prepare-phased-impl-archive.sh:35-67`
+- `codex/scripts/prepare-phased-impl-archive.sh:5-5`
+- `codex/scripts/prepare-phased-impl-archive.sh:72-72`
+- `codex/scripts/prepare-phased-impl-archive.sh:77-92`
+- `goals/task-manifest.csv:5-5`
+<!-- REVIEW-CONTEXT END -->
+
+## Findings JSON
+```json
+[]
+```
+
+## Overall Correctness Verdict
+- Verdict: patch is correct
+- Confidence: 0.91
+- Justification: The archive guard deterministically compares rendered phase templates and only skips archival when artifacts are template-only; substantive archive behavior remains intact and no actionable regressions were found.

--- a/tasks/no-empty-archive/revalidate.md
+++ b/tasks/no-empty-archive/revalidate.md
@@ -1,0 +1,24 @@
+# Revalidate
+- Task name: no-empty-archive
+- Trigger source: ready-for-reverification
+- Trigger evidence: Stage 4 validator emitted `READY FOR REVERIFICATION` after implementing deterministic template-comparison archive guard and recording full verification evidence in `final-phase.md`.
+- Final verdict: READY TO LAND
+
+## Locked upstream context (read-only)
+- Goals artifact: `goals/no-empty-archive/goals.v1.md` (`GOALS LOCKED`)
+- Prepare-takeoff outputs: `tasks/no-empty-archive/spec.md`, `codex/codex-config.yaml`, `codex/project-structure.md`
+
+## Drift and integrity reassessment
+- Goals/constraints integrity: pass
+- Scope/surface adherence: pass
+- Verification stability: pass
+- Progress budget evidence: pass
+- Implementation/reverification consistency: pass
+
+## Reverification findings
+1. Stage 3 lifecycle prerequisite is satisfied (`Stage 3 runs: 1`, `Drift revalidation count: 0`).
+2. Revalidation code review status is `none` with verdict `patch is correct`.
+3. No open actionable findings remain.
+
+## Next action
+- Execute `land-the-plan`.

--- a/tasks/no-empty-archive/risk-acceptance.md
+++ b/tasks/no-empty-archive/risk-acceptance.md
@@ -1,0 +1,11 @@
+# Risk Acceptance
+
+- Owner:
+- Justification:
+- Expiry: YYYY-MM-DD
+
+## Unresolved actionable findings
+- File:
+- Line range:
+- Severity:
+- Explanation:

--- a/tasks/no-empty-archive/spec.md
+++ b/tasks/no-empty-archive/spec.md
@@ -1,0 +1,139 @@
+# Prevent Archive On Template-Only Phase Files
+
+## Stage status
+- establish-goals verdict: `GOALS LOCKED` (`goals/no-empty-archive/goals.v1.md`)
+- prepare-takeoff verdict: `READY FOR PLANNING`
+- prepare-phased-impl verdict: `READY FOR IMPLEMENTATION`
+- implement verdict: `READY FOR REVERIFICATION`
+- revalidate verdict: `READY TO LAND`
+- Stage 2 evidence:
+  - Bootstrap config updated: `codex/codex-config.yaml`
+  - Task scaffold created: `tasks/no-empty-archive/`
+  - Safety prep executed: `./codex/scripts/prepare-takeoff-worktree.sh no-empty-archive`
+
+## Overview
+Prevent premature Stage 3 archival when `phase-1.md` and `phase-2.md` are still untouched generated templates. Archive should run only when there is meaningful planning content or other archive-worthy artifacts.
+
+## Goals
+1. Update archive detection so template-only `phase-1.md` and `phase-2.md` do not trigger archive.
+2. Use deterministic file-content comparison against expected template-rendered content.
+3. Preserve existing archive behavior when phase files diverge from template content or when `phase-plan.md` exists.
+4. Add verification evidence that covers both skip and archive paths.
+
+## Non-goals
+- Introducing mutable INIT/update tags in phase files.
+- Changing lifecycle stage verdict names/order.
+- Refactoring unrelated Stage 3 scripts or task artifacts.
+
+## Use cases / user stories
+- As a planner starting Stage 3, I do not want archive/noise created when phase files are untouched templates.
+- As a maintainer, I want deterministic logic that does not depend on manual tags.
+- As a reviewer, I can verify skip/archive behavior from explicit command evidence.
+
+## Current behavior
+- Notes:
+  - `prepare-phased-impl-archive.sh` archives whenever any `phase-*.md` exists.
+  - Newly scaffolded tasks always include phase files, so archive can run before any real planning content exists.
+- Key files:
+  - `codex/scripts/prepare-phased-impl-archive.sh`
+  - `codex/tasks/_templates/phase.template.md`
+  - `codex/scripts/prepare-phased-impl-scaffold.sh`
+
+## Proposed behavior
+- Behavior changes:
+  - `prepare-phased-impl-archive.sh` checks whether `phase-1.md` and `phase-2.md` exactly match the rendered template baselines.
+  - When both files are template-only and no `phase-plan.md` exists, script exits no-op and reports no Stage 3 artifacts to archive.
+  - Existing archive behavior remains unchanged for any substantive phase-file edits or `phase-plan.md` presence.
+- Edge cases:
+  - Missing template file is fail-fast.
+  - Non-existent `phase-1.md`/`phase-2.md` keeps current archive logic for other artifacts.
+  - Any whitespace/content drift from template counts as substantive and permits archive.
+
+## Technical design
+### Architecture / modules impacted
+- `codex/scripts/prepare-phased-impl-archive.sh`
+
+### Stage 2 governing context
+- Rules:
+  - `codex/rules/expand-task-spec.rules`
+  - `codex/rules/git-safe.rules`
+- Skills:
+  - `codex/skills/prepare-takeoff/SKILL.md`
+  - `codex/skills/prepare-phased-impl/SKILL.md`
+  - `codex/skills/implement/SKILL.md`
+  - `codex/skills/revalidate/SKILL.md`
+  - `codex/skills/land-the-plan/SKILL.md`
+- Sandbox constraints:
+  - Workspace-write filesystem sandbox
+  - No network required for implementation and local validation
+
+### API changes (if any)
+- None.
+
+### UI/UX changes (if any)
+- None.
+
+### Data model / schema changes (PostgreSQL)
+- Migrations: none
+- Backward compatibility: full; archive semantics only narrow premature archival
+- Rollback: revert `codex/scripts/prepare-phased-impl-archive.sh`
+
+## Security & privacy
+- No new secrets, auth, or external inputs.
+- Deterministic comparisons reduce ambiguous operator-driven state.
+
+## Observability (logs/metrics)
+- Archive script emits explicit reason when skipping template-only files.
+- Verification commands capture no-op and archive paths.
+
+## Verification Commands
+> Pin the exact commands discovered for this repo (also update canonical config docs when needed).
+
+- Lint:
+  - `not-configured`
+- Build:
+  - `not-configured`
+- Test:
+  - `not-configured`
+- Targeted checks:
+  - `./codex/scripts/prepare-phased-impl-archive.sh no-empty-archive`
+  - `./codex/scripts/prepare-phased-impl-scaffold.sh no-empty-archive surgical`
+  - `./codex/scripts/prepare-phased-impl-validate.sh no-empty-archive`
+  - `./codex/scripts/implement-validate.sh no-empty-archive`
+  - `./codex/scripts/revalidate-validate.sh no-empty-archive`
+
+## Test strategy
+- Unit:
+  - Validate template-comparison helper path by running archive script against untouched template files.
+- Integration:
+  - Run Stage 3/4/5 validators to ensure lifecycle compatibility.
+- E2E / UI (if applicable):
+  - n/a
+
+## Acceptance criteria checklist
+- [x] Archive script does not archive when both `phase-1.md` and `phase-2.md` are template-only.
+- [x] Deterministic template comparison is used instead of mutable state markers.
+- [x] Archive still runs when at least one phase file has substantive edits.
+- [x] Verification evidence recorded in task artifacts.
+
+## IN SCOPE
+- Implementing archive guard logic in `codex/scripts/prepare-phased-impl-archive.sh`.
+- Updating this task's lifecycle docs and verification evidence.
+
+## OUT OF SCOPE
+- Changes to Stage 3/4/5 verdict contracts.
+- Adding a dedicated shell test harness for this repository.
+
+## Execution posture lock
+- Simplicity bias: required.
+- Surgical-change discipline: required.
+- Fail-fast error handling: required.
+
+## Change control
+- Locked goals/constraints/success criteria from `goals/no-empty-archive/goals.v1.md` cannot change without relock.
+- Any scope expansion requires revalidate routing before implementation continues.
+
+## Implementation phase strategy
+- Complexity: surgical
+- Active phases: 1..2
+- No new scope introduced: required


### PR DESCRIPTION
## Goals
- Prevent premature Stage 3 archival when `phase-1.md` and `phase-2.md` are untouched generated templates.
- Use deterministic template-content comparison for archive eligibility.
- Preserve archive behavior when substantive phase edits exist or `phase-plan.md` is present.
- Record verification evidence for both no-op and archive paths.

## Non-goals
- Introduce mutable INIT/update markers in phase files.
- Change lifecycle stage verdict names or order.
- Refactor unrelated Stage 3 scripts or task artifacts.

## ADR
- None. This change keeps existing lifecycle architecture and narrows archive eligibility logic in place.

## Exceptions
- None.

## Deferred work
- No `//TODO` markers were found in changed files.
- Deferred in task closeout: add dedicated shell harness coverage for template/no-template archive branches.
- Deferred in task closeout: add end-to-end ACAC lifecycle automation coverage for this path.