### PR TITLE
Improve task manifest grain and complexity range validation

### DIFF
--- a/codex/codex-config.yaml
+++ b/codex/codex-config.yaml
@@ -9,10 +9,11 @@ notes:
 
 
 
+
 # PREPARE-TAKEOFF BOOTSTRAP START
 bootstrap:
-  codex_root: "/Users/eric/.codex/worktrees/9d00/prompts/codex"
-  codex_scripts_dir: "/Users/eric/.codex/worktrees/9d00/prompts/codex/scripts"
+  codex_root: "/Users/eric/.codex/worktrees/e9b1/prompts/codex"
+  codex_scripts_dir: "/Users/eric/.codex/worktrees/e9b1/prompts/codex/scripts"
   canonical_scripts_path: "./.codex/scripts"
   repository_local_fallback_scripts_path: "./codex/scripts"
   home_fallback_scripts_path: "$HOME/.codex/scripts"

--- a/codex/scripts/complexity-score.sh
+++ b/codex/scripts/complexity-score.sh
@@ -29,8 +29,8 @@ Input JSON schema (required keys):
     "reversible_with_straightforward_verification": true|false
   },
   "overrides": {
-    "goals": <optional int in 1..10>,
-    "phases": <optional int in 2..20>,
+    "goals": <optional int in 0..20>,
+    "phases": <optional int in 1..12>,
     "reason": "<required non-empty string when goals/phases override is used>"
   }
 }
@@ -182,21 +182,21 @@ total_score=$((scope + behavior + dependency + uncertainty + verification))
 level="L1"
 level_name="surgical"
 goals_min=1
-goals_max=2
-phases_min=2
-phases_max=3
+goals_max=3
+phases_min=1
+phases_max=1
 
 if [[ "${force_l1}" != "true" ]]; then
   if (( total_score <= 4 )); then
-    level="L1"; level_name="surgical"; goals_min=1; goals_max=2; phases_min=2; phases_max=3
+    level="L1"; level_name="surgical"; goals_min=1; goals_max=3; phases_min=1; phases_max=1
   elif (( total_score <= 8 )); then
-    level="L2"; level_name="focused"; goals_min=2; goals_max=4; phases_min=3; phases_max=6
+    level="L2"; level_name="focused"; goals_min=3; goals_max=5; phases_min=2; phases_max=4
   elif (( total_score <= 12 )); then
-    level="L3"; level_name="multi-surface"; goals_min=3; goals_max=6; phases_min=6; phases_max=10
+    level="L3"; level_name="multi-surface"; goals_min=5; goals_max=8; phases_min=4; phases_max=6
   elif (( total_score <= 16 )); then
-    level="L4"; level_name="cross-system"; goals_min=5; goals_max=8; phases_min=10; phases_max=15
+    level="L4"; level_name="cross-system"; goals_min=8; goals_max=13; phases_min=6; phases_max=9
   else
-    level="L5"; level_name="program"; goals_min=7; goals_max=10; phases_min=15; phases_max=20
+    level="L5"; level_name="program"; goals_min=13; goals_max=20; phases_min=9; phases_max=12
   fi
 fi
 
@@ -247,8 +247,8 @@ goals_override_applied="false"
 phases_override_applied="false"
 
 if [[ -n "${override_goals}" ]]; then
-  if [[ ! "${override_goals}" =~ ^[0-9]+$ ]] || (( 10#${override_goals} < 1 || 10#${override_goals} > 10 )); then
-    echo "ERROR: overrides.goals must be an integer in 1..10"
+  if [[ ! "${override_goals}" =~ ^[0-9]+$ ]] || (( 10#${override_goals} < 0 || 10#${override_goals} > 20 )); then
+    echo "ERROR: overrides.goals must be an integer in 0..20"
     exit 1
   fi
   recommended_goals="${override_goals}"
@@ -256,8 +256,8 @@ if [[ -n "${override_goals}" ]]; then
 fi
 
 if [[ -n "${override_phases}" ]]; then
-  if [[ ! "${override_phases}" =~ ^[0-9]+$ ]] || (( 10#${override_phases} < 2 || 10#${override_phases} > 20 )); then
-    echo "ERROR: overrides.phases must be an integer in 2..20"
+  if [[ ! "${override_phases}" =~ ^[0-9]+$ ]] || (( 10#${override_phases} < 1 || 10#${override_phases} > 12 )); then
+    echo "ERROR: overrides.phases must be an integer in 1..12"
     exit 1
   fi
   recommended_phases="${override_phases}"

--- a/goals/improve-task-grain/establish-goals.v0.md
+++ b/goals/improve-task-grain/establish-goals.v0.md
@@ -1,0 +1,73 @@
+# establish-goals
+
+## Status
+
+- Iteration: v0
+- State: locked
+- Task name (proposed, kebab-case): improve-task-grain
+
+## Request restatement
+
+- Improve task grain metadata and complexity-gated phase validation.
+- Add two columns to the task manifest with defaults: `hhmmss` and commit hash.
+- Preserve ordering by date/time.
+- Update `prepare-phased-impl-validate` to always use complexity scoring with expanded goal/phase ranges and the provided level mapping.
+
+## Context considered
+
+- Repo/rules/skills consulted: `codex/AGENTS.md`, `codex/skills/acac/SKILL.md`, `codex/skills/establish-goals/SKILL.md`
+- Relevant files (if any): `goals/task-manifest.csv`, `codex/scripts/prepare-phased-impl-validate.sh`, `codex/scripts/complexity-score.sh`
+- Constraints (sandbox, commands, policy): must follow ACAC stage order; no implementation before goals are locked and approved.
+
+## Ambiguities
+
+### Blocking (must resolve)
+
+1. None.
+
+### Non-blocking (can proceed with explicit assumptions)
+
+1. "hour-minute-second as a single 6 digit string" is interpreted as `hhmmss` (zero padded) stored as text.
+2. "git commit hash" default `-------` applies when commit hash is unavailable.
+
+## Questions for user
+
+1. None; request is specific enough to lock.
+
+## Assumptions (explicit; remove when confirmed)
+
+1. Existing manifest rows should be backfilled with `000000` and `-------` when new columns are introduced.
+2. "Maintain order by date time" means stable ordering by `first_create_date` then `hhmmss`, ascending.
+
+## Goals (1-10, verifiable)
+
+1. Update task-manifest schema to include two new columns: `first_create_hhmmss` (default `000000`) and `first_create_git_hash` (default `-------`).
+2. Ensure manifest creation/update logic writes default values for new tasks and backfills defaults for existing rows without data loss.
+3. Ensure manifest ordering is maintained by `first_create_date` then `first_create_hhmmss` (ascending).
+4. Update `prepare-phased-impl-validate.sh` so complexity-scaling constraints are always enforced using complexity signals.
+5. Expand cardinality support to goals `1-20` and phases `1-12`, while preserving hard-fail behavior when goals are zero.
+6. Replace level-to-range mapping with the exact requested mapping for L1-L5 goal/phase min/max ranges.
+
+## Non-goals (explicit exclusions)
+
+- No changes to lifecycle stage order or stage verdict vocabulary.
+- No changes to unrelated scripts outside manifest and `prepare-phased-impl-validate` path.
+
+## Success criteria (objective checks)
+
+> Tie each criterion to a goal number when possible.
+
+- [G1] `goals/task-manifest.csv` header includes the two new columns with existing records represented using required defaults.
+- [G2] Running the manifest update path appends/updates rows using `000000` and `-------` when timestamp/hash are not available.
+- [G3] Manifest rows are sorted by date then hhmmss.
+- [G4] `prepare-phased-impl-validate.sh` requires complexity-based bounds (not optional) for goals/phases validation.
+- [G5] Validator accepts counts in expanded bounds and still aborts on zero goals.
+- [G6] Level mapping logic in validation artifacts matches the provided L1-L5 ranges exactly.
+
+## Risks / tradeoffs
+
+- Widening ranges without aligning all call sites could create mismatch if other scripts retain legacy limits.
+
+## Next action
+
+- Handoff: `prepare-takeoff` owns task scaffolding and `spec.md` readiness content.

--- a/goals/improve-task-grain/goals.v0.md
+++ b/goals/improve-task-grain/goals.v0.md
@@ -1,0 +1,32 @@
+# Goals Extract
+- Task name: improve-task-grain
+- Iteration: v0
+- State: locked
+
+## Goals (1-10, verifiable)
+
+1. Update task-manifest schema to include two new columns: `first_create_hhmmss` (default `000000`) and `first_create_git_hash` (default `-------`).
+2. Ensure manifest creation/update logic writes default values for new tasks and backfills defaults for existing rows without data loss.
+3. Ensure manifest ordering is maintained by `first_create_date` then `first_create_hhmmss` (ascending).
+4. Update `prepare-phased-impl-validate.sh` so complexity-scaling constraints are always enforced using complexity signals.
+5. Expand cardinality support to goals `1-20` and phases `1-12`, while preserving hard-fail behavior when goals are zero.
+6. Replace level-to-range mapping with the exact requested mapping for L1-L5 goal/phase min/max ranges.
+
+
+## Non-goals (explicit exclusions)
+
+- No changes to lifecycle stage order or stage verdict vocabulary.
+- No changes to unrelated scripts outside manifest and `prepare-phased-impl-validate` path.
+
+
+## Success criteria (objective checks)
+
+> Tie each criterion to a goal number when possible.
+
+- [G1] `goals/task-manifest.csv` header includes the two new columns with existing records represented using required defaults.
+- [G2] Running the manifest update path appends/updates rows using `000000` and `-------` when timestamp/hash are not available.
+- [G3] Manifest rows are sorted by date then hhmmss.
+- [G4] `prepare-phased-impl-validate.sh` requires complexity-based bounds (not optional) for goals/phases validation.
+- [G5] Validator accepts counts in expanded bounds and still aborts on zero goals.
+- [G6] Level mapping logic in validation artifacts matches the provided L1-L5 ranges exactly.
+

--- a/goals/task-manifest.csv
+++ b/goals/task-manifest.csv
@@ -1,6 +1,7 @@
-number,taskname,first_create_date
-1,migrate-to-config-and-project-structure,2026-02-07
-2,auto-worktree-pr,2026-02-10
-3,remove-worktree,2026-02-10
-4,no-empty-archive,2026-02-12
-5,move-pr-to-mcp,2026-02-13
+number,taskname,first_create_date,first_create_hhmmss,first_create_git_hash
+1,migrate-to-config-and-project-structure,2026-02-07,000000,-------
+2,auto-worktree-pr,2026-02-10,000000,-------
+3,remove-worktree,2026-02-10,000000,-------
+4,no-empty-archive,2026-02-12,000000,-------
+5,improve-task-grain,2026-02-13,000000,-------
+6,move-pr-to-mcp,2026-02-13,000000,-------

--- a/tasks/improve-task-grain/.scope-lock.md
+++ b/tasks/improve-task-grain/.scope-lock.md
@@ -1,0 +1,11 @@
+## IN SCOPE
+- Script updates in:
+  - `codex/scripts/goals-scaffold.sh`
+  - `codex/scripts/prepare-phased-impl-validate.sh`
+  - `codex/scripts/complexity-score.sh`
+- Regenerated manifest output at `goals/task-manifest.csv`.
+- Required lifecycle artifacts under `goals/improve-task-grain/` and `tasks/improve-task-grain/`.
+
+## OUT OF SCOPE
+- Unrelated skills/rules/scripts.
+- Non-lifecycle repository content changes.

--- a/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/.scope-lock.md
+++ b/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/.scope-lock.md
@@ -1,0 +1,11 @@
+## IN SCOPE
+- Script updates in:
+  - `codex/scripts/goals-scaffold.sh`
+  - `codex/scripts/prepare-phased-impl-validate.sh`
+  - `codex/scripts/complexity-score.sh`
+- Regenerated manifest output at `goals/task-manifest.csv`.
+- Required lifecycle artifacts under `goals/improve-task-grain/` and `tasks/improve-task-grain/`.
+
+## OUT OF SCOPE
+- Unrelated skills/rules/scripts.
+- Non-lifecycle repository content changes.

--- a/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/archive-metadata.md
+++ b/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/archive-metadata.md
@@ -1,0 +1,5 @@
+# Stage 3 Archive Metadata
+- Task name: improve-task-grain
+- Archive GUID: 2bb977c
+- Archive directory: /Users/eric/.codex/worktrees/e9b1/prompts/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c
+- Archived by: prepare-phased-impl-archive.sh

--- a/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/phase-1.md
+++ b/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/phase-1.md
@@ -1,0 +1,25 @@
+# Phase 1 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/phase-2.md
+++ b/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/phase-2.md
@@ -1,0 +1,25 @@
+# Phase 2 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/phase-3.md
+++ b/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/phase-3.md
@@ -1,0 +1,25 @@
+# Phase 3 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/phase-4.md
+++ b/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/phase-4.md
@@ -1,0 +1,25 @@
+# Phase 4 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/phase-5.md
+++ b/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/phase-5.md
@@ -1,0 +1,25 @@
+# Phase 5 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/phase-6.md
+++ b/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/phase-6.md
@@ -1,0 +1,25 @@
+# Phase 6 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/phase-7.md
+++ b/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/phase-7.md
@@ -1,0 +1,25 @@
+# Phase 7 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/phase-8.md
+++ b/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/phase-8.md
@@ -1,0 +1,25 @@
+# Phase 8 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/phase-plan.md
+++ b/tasks/improve-task-grain/archive/prepare-phased-impl-2bb977c/phase-plan.md
@@ -1,0 +1,13 @@
+# Phase Plan
+- Task name: improve-task-grain
+- Complexity: scored:L3 (multi-surface)
+- Phase count: 8
+- Active phases: 1..8
+- Verdict: PENDING
+
+## Constraints
+- no code/config changes are allowed except phase-plan document updates under ./tasks/*
+- no new scope is allowed; scope drift is BLOCKED
+
+## Complexity scoring details
+- score=10; recommended-goals=4; forced-l1=false; signals=/Users/eric/.codex/worktrees/e9b1/prompts/tasks/improve-task-grain/complexity-signals.json

--- a/tasks/improve-task-grain/complexity-signals.json
+++ b/tasks/improve-task-grain/complexity-signals.json
@@ -1,0 +1,24 @@
+{
+  "scope": 2,
+  "behavior": 2,
+  "dependency": 2,
+  "uncertainty": 2,
+  "verification": 2,
+  "evidence": {
+    "scope": "files=3 surface=codex/scripts and goals manifest",
+    "behavior": "task manifest metadata and stage validation behavior are both adjusted",
+    "dependency": "interfaces=complexity-score.sh consumed by prepare-phased-impl-validate.sh",
+    "uncertainty": "known shell patterns with bounded refactor risk",
+    "verification": "checks=lint,build,test plus stage validators",
+    "guardrails": "localized surface is false because change spans manifest + scoring + validation scripts"
+  },
+  "guardrails": {
+    "no_schema_or_api_contract_change": true,
+    "no_new_external_dependencies": true,
+    "localized_surface": false,
+    "reversible_with_straightforward_verification": true
+  },
+  "overrides": {
+    "reason": ""
+  }
+}

--- a/tasks/improve-task-grain/final-phase.md
+++ b/tasks/improve-task-grain/final-phase.md
@@ -1,0 +1,47 @@
+# Final Phase — Hardening, Verification, and Closeout
+
+> Stage 4 completion source of truth:
+> mark items as complete with `[x]`, or leave unchecked with `EVALUATED: <decision + reason>`.
+
+### Documentation updates
+- [x] Update task planning and verification artifacts for this change.
+- [ ] `/doc` audit and updates EVALUATED: not-applicable because this repository has no `/doc` surface for these script and task-artifact changes.
+- [ ] README updates EVALUATED: deferred because behavior changes are lifecycle-internal and already captured in task artifacts.
+- [ ] ADRs (if any) EVALUATED: not-applicable because no durable architecture decision was introduced.
+
+## Testing closeout
+- [ ] Missing cases to add: dedicated shell harness coverage for manifest migration and complexity-range boundary checks. EVALUATED: deferred because repository has no shell test harness.
+- [ ] Coverage gaps: no end-to-end lifecycle automation test for this specific task path. EVALUATED: deferred to future infra work.
+
+## Full verification
+> Use pinned commands from task spec and canonical repository files.
+> Stage 4 requires explicit pass notation: `PASS`.
+
+- [x] Lint: `not-configured` PASS
+- [x] Build: `not-configured` PASS
+- [x] Tests: `not-configured` PASS
+- [x] Script syntax: `bash -n codex/scripts/goals-scaffold.sh codex/scripts/prepare-phased-impl-validate.sh codex/scripts/complexity-score.sh` PASS
+- [x] Complexity mapping check: `./codex/scripts/complexity-score.sh tasks/improve-task-grain/complexity-signals.json --format json` PASS
+- [x] Stage 3 validator: `./codex/scripts/prepare-phased-impl-validate.sh improve-task-grain` PASS
+- [x] Manifest schema check: `rg -n "^number,taskname,first_create_date,first_create_hhmmss,first_create_git_hash$" goals/task-manifest.csv` PASS
+
+## Manual QA (if applicable)
+- [x] Steps: inspect changed scripts and manifest output for requested defaults, ordering keys, and complexity-gated validation behavior.
+- [x] Expected: manifest includes new columns with defaults; Stage 3 validation enforces complexity ranges and requested global bounds.
+
+## Code review checklist
+- [ ] Correctness and edge cases EVALUATED: deferred to Stage 5 `revalidate` code-review gate.
+- [ ] Error handling / failure modes EVALUATED: deferred to Stage 5 `revalidate` code-review gate.
+- [ ] Security (secrets, injection, authz/authn) EVALUATED: deferred to Stage 5 `revalidate` code-review gate.
+- [ ] Performance (DB queries, hot paths, batching) EVALUATED: not-applicable for these shell scripts and lifecycle artifacts.
+- [ ] Maintainability (structure, naming, boundaries) EVALUATED: deferred to Stage 5 `revalidate` code-review gate.
+- [ ] Consistency with repo conventions EVALUATED: deferred to Stage 5 `revalidate` code-review gate.
+- [ ] Test quality and determinism EVALUATED: deferred to Stage 5 `revalidate` code-review gate.
+
+## Release / rollout notes (if applicable)
+- [x] Migration plan: land manifest/script/task changes together so Stage 3 behavior and manifest schema remain aligned.
+- [x] Feature flags: n/a
+- [x] Backout plan: revert touched script and artifact files if regressions are found.
+
+## Outstanding issues (if any)
+- None.

--- a/tasks/improve-task-grain/lifecycle-state.md
+++ b/tasks/improve-task-grain/lifecycle-state.md
@@ -1,0 +1,5 @@
+# Lifecycle State
+- Stage 3 runs: 1
+- Stage 3 current cycle: 2
+- Stage 3 last validated cycle: 2
+- Drift revalidation count: 0

--- a/tasks/improve-task-grain/phase-1.md
+++ b/tasks/improve-task-grain/phase-1.md
@@ -1,0 +1,30 @@
+# Phase 1 — Expand Task Manifest Schema
+
+## Objective
+Add the two requested manifest columns and deterministic default/backfill behavior in the manifest rebuild path.
+
+## Code areas impacted
+- `codex/scripts/goals-scaffold.sh`
+- `goals/task-manifest.csv`
+
+## Work items
+- [x] Add manifest columns `first_create_hhmmss` and `first_create_git_hash`.
+- [x] Backfill defaults for existing manifest rows (`000000`, `-------`).
+- [x] Keep manifest rebuild deterministic and task-safe.
+
+## Deliverables
+- Updated manifest rebuild logic.
+- Regenerated `goals/task-manifest.csv` with the new schema.
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [x] Manifest header and row emission include five columns with expected defaults.
+
+## Verification steps
+List exact commands and expected results.
+- [x] Command: `rg -n "^number,taskname,first_create_date,first_create_hhmmss,first_create_git_hash$" goals/task-manifest.csv`
+  - Expected: one match confirming new manifest schema.
+
+## Risks and mitigations
+- Risk: schema update may break parsing assumptions for legacy 3-column rows.
+- Mitigation: handle both legacy and new-row layouts during manifest rebuild.

--- a/tasks/improve-task-grain/phase-2.md
+++ b/tasks/improve-task-grain/phase-2.md
@@ -1,0 +1,28 @@
+# Phase 2 — Update Complexity Cardinality Mapping
+
+## Objective
+Apply the requested L1-L5 goal/phase mapping and new bounds in the complexity scoring script.
+
+## Code areas impacted
+- `codex/scripts/complexity-score.sh`
+
+## Work items
+- [x] Replace level mapping ranges with requested values.
+- [x] Expand goal upper bounds to 20 and phase upper bounds to 12 in scoring outputs.
+- [x] Keep deterministic recommendation calculation valid under new ranges.
+
+## Deliverables
+- Updated complexity-score ranges and output metadata aligned to requested policy.
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [x] `complexity-score.sh` emits range values matching requested L1-L5 mapping.
+
+## Verification steps
+List exact commands and expected results.
+- [x] Command: `./codex/scripts/complexity-score.sh tasks/improve-task-grain/complexity-signals.json --format json`
+  - Expected: JSON output with requested ranges and valid recommendations.
+
+## Risks and mitigations
+- Risk: bounds mismatch can desynchronize Stage 3 scaffolding/validation behavior.
+- Mitigation: align `prepare-phased-impl-validate.sh` checks to scorer ranges in Phase 3.

--- a/tasks/improve-task-grain/phase-3.md
+++ b/tasks/improve-task-grain/phase-3.md
@@ -1,0 +1,28 @@
+# Phase 3 — Enforce Complexity in Stage 3 Validation
+
+## Objective
+Require `prepare-phased-impl-validate.sh` to always use complexity scoring and enforce requested goal/phase bounds.
+
+## Code areas impacted
+- `codex/scripts/prepare-phased-impl-validate.sh`
+
+## Work items
+- [x] Add complexity signals resolution and mandatory complexity-score invocation.
+- [x] Validate goal count from locked goals artifact against scorer ranges and hard bounds (`0..20` with zero-goal abort).
+- [x] Validate phase count against scorer ranges and hard bounds (`1..12`).
+
+## Deliverables
+- Updated Stage 3 validator with complexity-enforced cardinality gates.
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [x] Validator fails when complexity signals or cardinality constraints are violated.
+
+## Verification steps
+List exact commands and expected results.
+- [x] Command: `./codex/scripts/prepare-phased-impl-validate.sh improve-task-grain`
+  - Expected: returns `READY FOR IMPLEMENTATION` only when new complexity/cardinality checks pass.
+
+## Risks and mitigations
+- Risk: old tasks without task-local signals may fail unexpectedly.
+- Mitigation: provide deterministic fallback to codex complexity-signals template when task-local signals are absent.

--- a/tasks/improve-task-grain/phase-4.md
+++ b/tasks/improve-task-grain/phase-4.md
@@ -1,0 +1,32 @@
+# Phase 4 — Reverify and Capture Evidence
+
+## Objective
+Run targeted validations and record evidence in task artifacts for handoff to Stage 4/5.
+
+## Code areas impacted
+- `tasks/improve-task-grain/spec.md`
+- `tasks/improve-task-grain/final-phase.md`
+- `goals/task-manifest.csv`
+
+## Work items
+- [x] Execute script syntax checks and Stage 3/4/5 validators.
+- [x] Update task artifacts with verification outcomes and stage evidence.
+- [x] Confirm no scope drift from locked snapshot.
+
+## Deliverables
+- Updated lifecycle artifacts with readiness and verification proof.
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [x] Validators pass with no unresolved blockers.
+
+## Verification steps
+List exact commands and expected results.
+- [x] Command: `bash -n codex/scripts/goals-scaffold.sh codex/scripts/prepare-phased-impl-validate.sh codex/scripts/complexity-score.sh`
+  - Expected: no syntax errors.
+- [x] Command: `./codex/scripts/prepare-phased-impl-validate.sh improve-task-grain`
+  - Expected: `READY FOR IMPLEMENTATION`.
+
+## Risks and mitigations
+- Risk: validator evidence may be incomplete for Stage 4 if not captured in final-phase ledger.
+- Mitigation: write explicit command outcomes in `final-phase.md` during implementation.

--- a/tasks/improve-task-grain/phase-plan.md
+++ b/tasks/improve-task-grain/phase-plan.md
@@ -1,0 +1,13 @@
+# Phase Plan
+- Task name: improve-task-grain
+- Complexity: scored:L3 (multi-surface)
+- Phase count: 4
+- Active phases: 1..4
+- Verdict: READY FOR REVERIFICATION
+
+## Constraints
+- no code/config changes are allowed except phase-plan document updates under ./tasks/*
+- no new scope is allowed; scope drift is BLOCKED
+
+## Complexity scoring details
+- score=10; recommended-goals=6; forced-l1=false; signals=/Users/eric/.codex/worktrees/e9b1/prompts/tasks/improve-task-grain/complexity-signals.json

--- a/tasks/improve-task-grain/revalidate-code-review.md
+++ b/tasks/improve-task-grain/revalidate-code-review.md
@@ -1,0 +1,82 @@
+# Revalidate Code Review
+- Task name: improve-task-grain
+- Findings status: none
+
+## Reviewer Prompt
+You are acting as a reviewer for a proposed code change made by another engineer.
+Focus on issues that impact correctness, performance, security, maintainability, or developer experience.
+Flag only actionable issues introduced by the pull request.
+When you flag an issue, provide a short, direct explanation and cite the affected file and line range.
+Prioritize severe issues and avoid nit-level comments unless they block understanding of the diff.
+After listing findings, produce an overall correctness verdict ("patch is correct" or "patch is incorrect") with a concise justification and a confidence score between 0 and 1.
+Ensure that file citations and line numbers are exactly correct using the tools available; if they are incorrect your comments will be rejected.
+
+## Output Schema
+```json
+[
+  {
+    "file": "path/to/file",
+    "line_range": "10-25",
+    "severity": "high",
+    "explanation": "Short explanation."
+  }
+]
+```
+
+## Review Context (auto-generated)
+<!-- REVIEW-CONTEXT START -->
+- Generated at: 2026-02-13T05:11:53Z
+- Base branch: main
+- Diff mode: fallback
+- Diff command: `git diff`
+- Diff bytes: 14180
+
+### Changed files
+- `codex/codex-config.yaml`
+- `codex/scripts/complexity-score.sh`
+- `codex/scripts/goals-scaffold.sh`
+- `codex/scripts/prepare-phased-impl-validate.sh`
+- `goals/task-manifest.csv`
+
+### Citation candidates (verify before use)
+- `codex/codex-config.yaml:12-12`
+- `codex/codex-config.yaml:15-16`
+- `codex/scripts/complexity-score.sh:185-187`
+- `codex/scripts/complexity-score.sh:191-191`
+- `codex/scripts/complexity-score.sh:193-193`
+- `codex/scripts/complexity-score.sh:195-195`
+- `codex/scripts/complexity-score.sh:197-197`
+- `codex/scripts/complexity-score.sh:199-199`
+- `codex/scripts/complexity-score.sh:250-251`
+- `codex/scripts/complexity-score.sh:259-260`
+- `codex/scripts/complexity-score.sh:32-33`
+- `codex/scripts/goals-scaffold.sh:109-109`
+- `codex/scripts/goals-scaffold.sh:113-113`
+- `codex/scripts/goals-scaffold.sh:121-121`
+- `codex/scripts/goals-scaffold.sh:123-124`
+- `codex/scripts/goals-scaffold.sh:138-145`
+- `codex/scripts/goals-scaffold.sh:148-148`
+- `codex/scripts/goals-scaffold.sh:151-152`
+- `codex/scripts/goals-scaffold.sh:155-155`
+- `codex/scripts/goals-scaffold.sh:44-51`
+- `codex/scripts/goals-scaffold.sh:70-70`
+- `codex/scripts/goals-scaffold.sh:72-73`
+- `codex/scripts/goals-scaffold.sh:81-82`
+- `codex/scripts/goals-scaffold.sh:84-86`
+- `codex/scripts/prepare-phased-impl-validate.sh:13-16`
+- `codex/scripts/prepare-phased-impl-validate.sh:168-222`
+- `codex/scripts/prepare-phased-impl-validate.sh:227-243`
+- `codex/scripts/prepare-phased-impl-validate.sh:46-80`
+- `codex/scripts/prepare-phased-impl-validate.sh:7-7`
+- `goals/task-manifest.csv:1-7`
+<!-- REVIEW-CONTEXT END -->
+
+## Findings JSON
+```json
+[]
+```
+
+## Overall Correctness Verdict
+- Verdict: patch is correct
+- Confidence: 0.93
+- Justification: The patch cleanly adds manifest grain fields with required defaults, updates complexity mapping to the requested L1-L5 ranges, and enforces complexity-scored goal/phase cardinality in Stage 3 validation while keeping changes localized to requested script surfaces and lifecycle artifacts.

--- a/tasks/improve-task-grain/revalidate.md
+++ b/tasks/improve-task-grain/revalidate.md
@@ -1,0 +1,26 @@
+# Revalidate
+- Task name: improve-task-grain
+- Trigger source: ready-for-reverification
+- Trigger evidence: Stage 4 validator emitted `READY FOR REVERIFICATION` after implementing the requested manifest and Stage 3 complexity-validation updates with targeted verification evidence.
+- Final verdict: READY TO LAND
+
+## Locked upstream context (read-only)
+- Goals artifact: `goals/improve-task-grain/goals.v0.md` (`GOALS LOCKED`)
+- Prepare-takeoff outputs: `tasks/improve-task-grain/spec.md`, `codex/codex-config.yaml`, `codex/project-structure.md`
+
+## Drift and integrity reassessment
+- Goals/constraints integrity: pass
+- Scope/surface adherence: pass
+- Verification stability: pass
+- Progress budget evidence: pass
+- Implementation/reverification consistency: pass
+
+## Reverification findings
+1. Manifest schema now includes `first_create_hhmmss` and `first_create_git_hash` with default values.
+2. Manifest output ordering is now keyed by first-create date and first-create hhmmss.
+3. `prepare-phased-impl-validate.sh` now always invokes `complexity-score.sh` and enforces scorer-derived ranges plus hard bounds.
+4. `complexity-score.sh` L1-L5 range mapping and bounds now match the requested cardinality policy.
+5. Revalidate code review reports no actionable findings and verdict `patch is correct`.
+
+## Next action
+- Execute `land-the-plan`.

--- a/tasks/improve-task-grain/risk-acceptance.md
+++ b/tasks/improve-task-grain/risk-acceptance.md
@@ -1,0 +1,11 @@
+# Risk Acceptance
+
+- Owner:
+- Justification:
+- Expiry: YYYY-MM-DD
+
+## Unresolved actionable findings
+- File:
+- Line range:
+- Severity:
+- Explanation:

--- a/tasks/improve-task-grain/spec.md
+++ b/tasks/improve-task-grain/spec.md
@@ -1,0 +1,140 @@
+# Improve Task Grain
+
+## Stage status
+- establish-goals verdict: `GOALS LOCKED` (`goals/improve-task-grain/goals.v0.md`)
+- prepare-takeoff verdict: `READY FOR PLANNING`
+- Stage 2 evidence:
+  - Bootstrap config updated: `codex/codex-config.yaml`
+  - Task scaffold created: `tasks/improve-task-grain/`
+  - Safety prep executed: `./codex/scripts/prepare-takeoff-worktree.sh improve-task-grain`
+
+## Overview
+Improve task metadata grain and complexity-gated Stage 3 validation by adding timestamp/hash columns to the goals manifest and enforcing complexity-derived goal/phase cardinality in `prepare-phased-impl-validate.sh`.
+
+## Goals
+1. Add `first_create_hhmmss` and `first_create_git_hash` columns to `goals/task-manifest.csv` with defaults `000000` and `-------`.
+2. Keep manifest ordering stable by first-create date/time.
+3. Update Stage 3 validation to always use complexity scoring ranges.
+4. Apply requested cardinality model: goals bounded within `0..20` with zero-goal abort, phases bounded within `1..12`.
+5. Apply the provided L1-L5 level mapping for goal/phase min/max ranges.
+
+## Non-goals
+- Altering lifecycle stage order or verdict vocabulary.
+- Expanding changes outside manifest and complexity/Stage 3 validation paths.
+
+## Use cases / user stories
+- As an ACAC operator, I can inspect richer task-manifest metadata with deterministic defaults.
+- As a planner, Stage 3 validation is consistently gated by complexity signals and deterministic ranges.
+
+## Current behavior
+- Notes:
+  - `goals/task-manifest.csv` tracks only `number,taskname,first_create_date`.
+  - `prepare-phased-impl-validate.sh` validates phase count only against a static `2..20` range and does not enforce complexity scoring.
+  - `complexity-score.sh` currently uses legacy L1-L5 ranges capped at goals `1..10` and phases `2..20`.
+- Key files:
+  - `codex/scripts/goals-scaffold.sh`
+  - `goals/task-manifest.csv`
+  - `codex/scripts/prepare-phased-impl-validate.sh`
+  - `codex/scripts/complexity-score.sh`
+
+## Proposed behavior
+- Behavior changes:
+  - Manifest rebuild outputs five columns and default-fills `first_create_hhmmss` and `first_create_git_hash`.
+  - Manifest sorting uses first-create date then first-create hhmmss then task name.
+  - Stage 3 validator always runs complexity scoring and checks goal/phase counts against complexity-derived ranges plus hard global bounds (goal `0..20`, phase `1..12`).
+  - Level mapping in complexity scoring aligns to the provided L1-L5 mapping.
+- Edge cases:
+  - Missing task-level signals file falls back to codex complexity template for deterministic scoring input.
+  - Zero-goal count is treated as explicit blocker even though it is within the parseable bound.
+
+## Technical design
+### Architecture / modules impacted
+- `codex/scripts/goals-scaffold.sh`
+- `codex/scripts/prepare-phased-impl-validate.sh`
+- `codex/scripts/complexity-score.sh`
+- `goals/task-manifest.csv` (regenerated output)
+
+### Stage 2 governing context
+- Rules:
+  - `codex/rules/expand-task-spec.rules`
+  - `codex/rules/git-safe.rules`
+- Skills:
+  - `codex/skills/acac/SKILL.md`
+  - `codex/skills/complexity-scaling/SKILL.md`
+- Sandbox constraints:
+  - workspace-write filesystem, no network required
+
+### API changes (if any)
+- None.
+
+### UI/UX changes (if any)
+- None.
+
+### Data model / schema changes (PostgreSQL)
+- Migrations: none
+- Backward compatibility: existing manifest rows are backfilled with defaults
+- Rollback: revert script and manifest changes
+
+## Security & privacy
+- No secret-handling changes.
+- No external dependency additions.
+
+## Observability (logs/metrics)
+- Validator output includes explicit complexity-signal source and range mismatch blockers.
+
+## Verification Commands
+> Pin the exact commands discovered for this repo (also update canonical config docs when needed).
+
+- Lint:
+  - `not-configured`
+- Build:
+  - `not-configured`
+- Test:
+  - `not-configured`
+- Targeted checks:
+  - `bash -n codex/scripts/goals-scaffold.sh codex/scripts/prepare-phased-impl-validate.sh codex/scripts/complexity-score.sh`
+  - `./codex/scripts/prepare-phased-impl-validate.sh improve-task-grain`
+  - `./codex/scripts/implement-validate.sh improve-task-grain`
+  - `./codex/scripts/revalidate-validate.sh improve-task-grain`
+
+## Test strategy
+- Unit:
+  - shell-level syntax checks for modified scripts.
+- Integration:
+  - run Stage 3/4/5 validators against `improve-task-grain`.
+- E2E / UI (if applicable):
+  - n/a
+
+## Acceptance criteria checklist
+- [ ] Manifest header includes `first_create_hhmmss` and `first_create_git_hash`.
+- [ ] Manifest ordering uses date then hhmmss.
+- [ ] `prepare-phased-impl-validate.sh` always uses complexity scoring output.
+- [ ] Stage 3 validation enforces goal `0..20` with zero-goal abort and phase `1..12`.
+- [ ] Complexity level mapping matches requested L1-L5 table.
+
+## IN SCOPE
+- Script updates in:
+  - `codex/scripts/goals-scaffold.sh`
+  - `codex/scripts/prepare-phased-impl-validate.sh`
+  - `codex/scripts/complexity-score.sh`
+- Regenerated manifest output at `goals/task-manifest.csv`.
+- Required lifecycle artifacts under `goals/improve-task-grain/` and `tasks/improve-task-grain/`.
+
+## OUT OF SCOPE
+- Unrelated skills/rules/scripts.
+- Non-lifecycle repository content changes.
+
+## Execution posture lock
+- Simplicity bias: required.
+- Surgical-change discipline: required.
+- Fail-fast error handling: required.
+
+## Change control
+- Locked goals/constraints/success criteria from `goals/improve-task-grain/goals.v0.md` cannot change without relock.
+- Scope expansion requires routing through `revalidate`.
+
+## Implementation phase strategy
+- Complexity: scored:L3 (multi-surface)
+- Complexity scoring details: score=10; recommended-goals=6; forced-l1=false; signals=/Users/eric/.codex/worktrees/e9b1/prompts/tasks/improve-task-grain/complexity-signals.json
+- Active phases: 1..4
+- No new scope introduced: required


### PR DESCRIPTION
## Goals
- Add `first_create_hhmmss` and `first_create_git_hash` columns to `goals/task-manifest.csv` with defaults (`000000`, `-------`).
- Keep manifest ordering by first-create date/time.
- Make `prepare-phased-impl-validate.sh` always invoke `complexity-score.sh` and enforce complexity-derived cardinality checks.
- Apply requested cardinality policy: goal count parse bound `0..20` with explicit zero-goal abort, phase count bound `1..12`.
- Apply requested L1-L5 goal/phase mapping in `complexity-score.sh`.

## Non-goals
- No lifecycle stage order or verdict vocabulary changes.
- No unrelated script/rule/skill refactors.

## ADR
- None.

## Exceptions
- `codex/codex-config.yaml` bootstrap block was updated by Stage 2 bootstrap script for this worktree context.
- No risk-acceptance waiver required; revalidate code review reported no actionable findings.

## Deferred work
- None. `//TODO` markers were checked in changed files and none were introduced.