### PR TITLE
Add wrapper-based GitHub CLI auth routing

### DIFF
--- a/codex/codex-config.yaml
+++ b/codex/codex-config.yaml
@@ -1,9 +1,17 @@
 code_review:
   base_branch: main
 
+github_cli:
+  owner_token_env:
+    example-owner: GH_EXAMPLE_TOKEN
+
 notes:
   - "Update this manifest only when the repository's canonical commands change."
   - "Tasks must also copy the chosen commands into /tasks/<task-name>/spec.md under Verification Commands."
+  - "github_cli.owner_token_env maps a GitHub owner/org to the env var name a wrapper should use for GH_TOKEN rebinding."
+  - "Store env var names only; never store token values in this file."
+
+
 
 
 
@@ -19,8 +27,8 @@ notes:
 
 # PREPARE-TAKEOFF BOOTSTRAP START
 bootstrap:
-  codex_root: "/Users/eric/side-projects/prompts/codex"
-  codex_scripts_dir: "/Users/eric/side-projects/prompts/codex/scripts"
+  codex_root: "/Users/eric/.codex/worktrees/898e/prompts/codex"
+  codex_scripts_dir: "/Users/eric/.codex/worktrees/898e/prompts/codex/scripts"
   canonical_scripts_path: "./.codex/scripts"
   repository_local_fallback_scripts_path: "./codex/scripts"
   home_fallback_scripts_path: "$HOME/.codex/scripts"

--- a/codex/prompts/self-improve-skills.md
+++ b/codex/prompts/self-improve-skills.md
@@ -92,10 +92,10 @@ Use a body with these fields:
 When using the GitHub CLI, use the central repository explicitly:
 
 ```bash
-gh issue create --repo ericpassmore/prompts --title "<skill-or-stage>: <incident summary>" --body-file <body-file>
+./codex/scripts/gh-wrap.sh issue create --repo ericpassmore/prompts --title "<skill-or-stage>: <incident summary>" --body-file <body-file>
 ```
 
-The allowed CLI path is intentionally narrow. Do not broaden it to unrelated repositories or GitHub operations.
+The allowed CLI path is intentionally narrow. Do not broaden it to unrelated repositories or GitHub operations. If wrapper auth fails on create, the user may be prompted to run `./codex/scripts/gh-auth-check.sh --repo ericpassmore/prompts`, but the diagnostic must never be run automatically.
 
 ## Incident Categories
 

--- a/codex/rules/git-safe.rules
+++ b/codex/rules/git-safe.rules
@@ -118,39 +118,156 @@ prefix_rule(
 )
 
 prefix_rule(
-    pattern = ["gh", "pr", "create"],
+    pattern = ["./codex/scripts/gh-wrap.sh", "pr", "create"],
     decision = "allow",
-    justification = "Allow PR creation as fallback when GitHub MCP PR creation fails with permission/auth-access errors.",
+    justification = "Allow wrapper-based PR creation fallback after GitHub MCP auth-access failure.",
     match = [
-        "gh pr create --base main --head land-the-plan/task/agent-20260210120000 --title \"Title\" --body \"Body\"",
+        "./codex/scripts/gh-wrap.sh pr create --base main --head land-the-plan/task/agent-20260210120000 --title \"Title\" --body \"Body\"",
     ],
 )
 
 prefix_rule(
-    pattern = ["gh", "pr", "view"],
+    pattern = ["./codex/scripts/gh-wrap.sh", "pr", "view"],
     decision = "allow",
-    justification = "Allow checking whether a PR already exists for the resolved head branch during land-the-plan fallback.",
+    justification = "Allow wrapper-based PR lookup during fallback.",
     match = [
-        "gh pr view land-the-plan/task/agent-20260210120000 --json number,url",
+        "./codex/scripts/gh-wrap.sh pr view land-the-plan/task/agent-20260210120000 --json number,url",
     ],
 )
 
 prefix_rule(
-    pattern = ["gh", "pr", "edit"],
+    pattern = ["./codex/scripts/gh-wrap.sh", "pr", "edit"],
     decision = "allow",
-    justification = "Allow updating an existing PR during land-the-plan fallback when MCP PR access fails.",
+    justification = "Allow wrapper-based PR update during fallback.",
     match = [
-        "gh pr edit 123 --title \"Title\" --body \"Body\"",
+        "./codex/scripts/gh-wrap.sh pr edit 123 --title \"Title\" --body \"Body\"",
     ],
 )
 
 prefix_rule(
-    pattern = ["gh", "issue", "create"],
+    pattern = ["./codex/scripts/gh-wrap.sh", "pr", "list"],
     decision = "allow",
-    justification = "Allow issue creation in ericpassmore/prompts for the issue-first skill-improvement workflow.",
+    justification = "Allow wrapper-based PR listing for explicit operator workflows.",
     match = [
-        "gh issue create --repo ericpassmore/prompts --title \"skill: summary\" --body \"Body\"",
-        "gh issue create --repo ericpassmore/prompts --title \"skill: summary\" --body-file /tmp/issue.md",
+        "./codex/scripts/gh-wrap.sh pr list --repo ericpassmore/prompts",
+    ],
+)
+
+prefix_rule(
+    pattern = ["./codex/scripts/gh-wrap.sh", "pr", "comment"],
+    decision = "allow",
+    justification = "Allow wrapper-based PR comment creation for explicit operator workflows.",
+    match = [
+        "./codex/scripts/gh-wrap.sh pr comment 123 --body \"Body\"",
+    ],
+)
+
+prefix_rule(
+    pattern = ["./codex/scripts/gh-wrap.sh", "pr", "status"],
+    decision = "allow",
+    justification = "Allow wrapper-based PR status checks.",
+    match = [
+        "./codex/scripts/gh-wrap.sh pr status --repo ericpassmore/prompts",
+    ],
+)
+
+prefix_rule(
+    pattern = ["./codex/scripts/gh-wrap.sh", "pr", "close"],
+    decision = "allow",
+    justification = "Allow wrapper-based PR close operations for explicit operator workflows.",
+    match = [
+        "./codex/scripts/gh-wrap.sh pr close 123 --repo ericpassmore/prompts",
+    ],
+)
+
+prefix_rule(
+    pattern = ["./codex/scripts/gh-wrap.sh", "pr", "reopen"],
+    decision = "allow",
+    justification = "Allow wrapper-based PR reopen operations for explicit operator workflows.",
+    match = [
+        "./codex/scripts/gh-wrap.sh pr reopen 123 --repo ericpassmore/prompts",
+    ],
+)
+
+prefix_rule(
+    pattern = ["./codex/scripts/gh-wrap.sh", "edit"],
+    decision = "allow",
+    justification = "Allow the wrapper alias for PR edit workflows.",
+    match = [
+        "./codex/scripts/gh-wrap.sh edit 123 --title \"Title\" --body \"Body\"",
+    ],
+)
+
+prefix_rule(
+    pattern = ["./codex/scripts/gh-wrap.sh", "issue", "create"],
+    decision = "allow",
+    justification = "Allow wrapper-based issue creation in ericpassmore/prompts for the issue-first workflow.",
+    match = [
+        "./codex/scripts/gh-wrap.sh issue create --repo ericpassmore/prompts --title \"skill: summary\" --body \"Body\"",
+        "./codex/scripts/gh-wrap.sh issue create --repo ericpassmore/prompts --title \"skill: summary\" --body-file /tmp/issue.md",
+    ],
+)
+
+prefix_rule(
+    pattern = ["./codex/scripts/gh-wrap.sh", "issue", "delete"],
+    decision = "allow",
+    justification = "Allow wrapper-based issue deletion for manual auth diagnostics.",
+    match = [
+        "./codex/scripts/gh-wrap.sh issue delete 123 --repo ericpassmore/prompts --yes",
+    ],
+)
+
+prefix_rule(
+    pattern = ["./codex/scripts/gh-wrap.sh", "issue", "edit"],
+    decision = "allow",
+    justification = "Allow wrapper-based issue edits for explicit operator workflows.",
+    match = [
+        "./codex/scripts/gh-wrap.sh issue edit 123 --repo ericpassmore/prompts --title \"Title\"",
+    ],
+)
+
+prefix_rule(
+    pattern = ["./codex/scripts/gh-wrap.sh", "issue", "list"],
+    decision = "allow",
+    justification = "Allow wrapper-based issue listing for explicit operator workflows.",
+    match = [
+        "./codex/scripts/gh-wrap.sh issue list --repo ericpassmore/prompts",
+    ],
+)
+
+prefix_rule(
+    pattern = ["./codex/scripts/gh-wrap.sh", "issue", "close"],
+    decision = "allow",
+    justification = "Allow wrapper-based issue close operations for explicit operator workflows.",
+    match = [
+        "./codex/scripts/gh-wrap.sh issue close 123 --repo ericpassmore/prompts",
+    ],
+)
+
+prefix_rule(
+    pattern = ["./codex/scripts/gh-wrap.sh", "issue", "reopen"],
+    decision = "allow",
+    justification = "Allow wrapper-based issue reopen operations for explicit operator workflows.",
+    match = [
+        "./codex/scripts/gh-wrap.sh issue reopen 123 --repo ericpassmore/prompts",
+    ],
+)
+
+prefix_rule(
+    pattern = ["./codex/scripts/gh-wrap.sh", "label", "create"],
+    decision = "allow",
+    justification = "Allow wrapper-based label creation for explicit operator workflows.",
+    match = [
+        "./codex/scripts/gh-wrap.sh label create example --repo ericpassmore/prompts --description \"Example\" --color FF0000",
+    ],
+)
+
+prefix_rule(
+    pattern = ["./codex/scripts/gh-auth-check.sh"],
+    decision = "allow",
+    justification = "Allow explicit manual GitHub auth diagnostics through the wrapper-based check script.",
+    match = [
+        "./codex/scripts/gh-auth-check.sh --repo ericpassmore/prompts",
     ],
 )
 

--- a/codex/scripts/gh-auth-check.sh
+++ b/codex/scripts/gh-auth-check.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+resolve_config_path() {
+  if [[ -f "${ROOT_DIR}/codex/codex-config.yaml" ]]; then
+    printf '%s\n' "${ROOT_DIR}/codex/codex-config.yaml"
+    return 0
+  fi
+
+  if [[ -f "${ROOT_DIR}/.codex/codex-config.yaml" ]]; then
+    printf '%s\n' "${ROOT_DIR}/.codex/codex-config.yaml"
+    return 0
+  fi
+
+  if [[ -f "${HOME}/.codex/codex-config.yaml" ]]; then
+    printf '%s\n' "${HOME}/.codex/codex-config.yaml"
+    return 0
+  fi
+
+  return 1
+}
+
+github_cli_block() {
+  local config_path="$1"
+  awk '
+    /^github_cli:/ { in_block=1; next }
+    in_block && /^[^[:space:]]/ { exit }
+    in_block { print }
+  ' "${config_path}"
+}
+
+configured_token_env_for_owner() {
+  local owner_lc="$1"
+  local config_path="$2"
+
+  github_cli_block "${config_path}" | awk -v owner="${owner_lc}" '
+    /^  owner_token_env:[[:space:]]*$/ { in_map=1; next }
+    in_map && /^  [A-Za-z0-9_.-]+:[[:space:]]*/ { exit }
+    in_map {
+      line=$0
+      if (line ~ /^    /) {
+        key=line
+        value=line
+        sub(/^    /, "", key)
+        sub(/:.*/, "", key)
+        sub(/^    [^:]+:[[:space:]]*/, "", value)
+        gsub(/"/, "", value)
+        sub(/[[:space:]]*$/, "", value)
+        if (tolower(key) == owner) {
+          print value
+          exit
+        }
+      }
+    }
+  '
+}
+
+repo_slug_from_args() {
+  local -a args=("$@")
+  local idx=0
+
+  while (( idx < ${#args[@]} )); do
+    case "${args[idx]}" in
+      --repo|-R)
+        if (( idx + 1 >= ${#args[@]} )); then
+          echo "ERROR: ${args[idx]} requires an owner/repo argument" >&2
+          return 2
+        fi
+        printf '%s\n' "${args[idx + 1]}"
+        return 0
+        ;;
+      --repo=*|-R=*)
+        printf '%s\n' "${args[idx]#*=}"
+        return 0
+        ;;
+    esac
+    idx=$((idx + 1))
+  done
+
+  return 1
+}
+
+repo_slug_from_origin() {
+  local remote_url=""
+  remote_url="$(git config --get remote.origin.url 2>/dev/null || true)"
+
+  if [[ -z "${remote_url}" ]]; then
+    echo "ERROR: unable to infer repository owner/repo from remote.origin.url; pass --repo owner/name" >&2
+    return 2
+  fi
+
+  printf '%s\n' "${remote_url}" | sed -nE 's#^.*github\.com[:/]([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)(\.git)?$#\1#p' | head -n 1
+}
+
+resolve_repo_slug() {
+  local slug=""
+
+  slug="$(repo_slug_from_args "$@" 2>/dev/null || true)"
+  if [[ -n "${slug}" ]]; then
+    printf '%s\n' "${slug}"
+    return 0
+  fi
+
+  slug="$(repo_slug_from_origin)"
+  if [[ -z "${slug}" ]]; then
+    echo "ERROR: unable to resolve GitHub owner/repo" >&2
+    return 2
+  fi
+
+  printf '%s\n' "${slug}"
+}
+
+prepare_github_cli_env() {
+  local slug="$1"
+  local owner="${slug%%/*}"
+  local owner_lc="${owner,,}"
+  local config_path=""
+  local token_env=""
+
+  config_path="$(resolve_config_path 2>/dev/null || true)"
+  if [[ -n "${config_path}" ]]; then
+    token_env="$(configured_token_env_for_owner "${owner_lc}" "${config_path}")"
+  else
+    token_env=""
+  fi
+
+  if [[ -z "${token_env}" ]]; then
+    return 0
+  fi
+
+  if [[ -z "${!token_env:-}" ]]; then
+    echo "AUTH BLOCKED: owner/org '${owner}' maps to env var '${token_env}', but that env var is unset." >&2
+    echo "Update the environment or adjust github_cli.owner_token_env in codex-config.yaml." >&2
+    return 4
+  fi
+
+  export GH_TOKEN="${!token_env}"
+  return 0
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./codex/scripts/gh-auth-check.sh [--repo owner/name]
+
+Exit codes:
+  0  login and temporary issue create/delete succeeded
+  3  gh auth status failed
+  4  configured mapped env var is missing
+  5  temporary issue create failed
+  6  temporary issue delete failed
+EOF
+}
+
+main() {
+  local slug=""
+  local title=""
+  local body=""
+  local create_output=""
+  local delete_output=""
+  local issue_number=""
+
+  if (( $# > 0 )); then
+    case "$1" in
+      --help|-h)
+        usage
+        return 0
+        ;;
+    esac
+  fi
+
+  slug="$(resolve_repo_slug "$@")"
+  prepare_github_cli_env "${slug}"
+
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "AUTH CHECK FAILED: gh auth status did not succeed." >&2
+    return 3
+  fi
+
+  title="GH auth check $(date -u +%Y%m%dT%H%M%SZ)"
+  body="Temporary diagnostic issue created by gh-auth-check.sh and expected to be deleted immediately."
+
+  if ! create_output="$("${SCRIPT_DIR}/gh-wrap.sh" issue create --repo "${slug}" --title "${title}" --body "${body}" 2>&1)"; then
+    printf '%s\n' "${create_output}" >&2
+    echo "AUTH CHECK FAILED: issue create did not succeed." >&2
+    return 5
+  fi
+
+  issue_number="$(printf '%s\n' "${create_output}" | sed -nE 's#.*/issues/([0-9]+)$#\1#p' | tail -n 1)"
+  if [[ -z "${issue_number}" ]]; then
+    printf '%s\n' "${create_output}" >&2
+    echo "AUTH CHECK FAILED: issue create succeeded but issue number could not be parsed for cleanup." >&2
+    return 6
+  fi
+
+  if ! delete_output="$("${SCRIPT_DIR}/gh-wrap.sh" issue delete "${issue_number}" --repo "${slug}" --yes 2>&1)"; then
+    printf '%s\n' "${delete_output}" >&2
+    echo "AUTH CHECK FAILED: temporary diagnostic issue #${issue_number} could not be deleted." >&2
+    return 6
+  fi
+
+  echo "AUTH CHECK PASSED: login, create, and delete all succeeded for ${slug}."
+}
+
+main "$@"

--- a/codex/scripts/gh-auth-check.sh
+++ b/codex/scripts/gh-auth-check.sh
@@ -47,8 +47,16 @@ configured_token_env_for_owner() {
         sub(/^    /, "", key)
         sub(/:.*/, "", key)
         sub(/^    [^:]+:[[:space:]]*/, "", value)
-        gsub(/"/, "", value)
+        sub(/[[:space:]]+#.*$/, "", value)
+        sub(/^[[:space:]]+/, "", value)
         sub(/[[:space:]]*$/, "", value)
+        if (value ~ /^".*"$/) {
+          sub(/^"/, "", value)
+          sub(/"$/, "", value)
+        } else if (value ~ /^\047.*\047$/) {
+          sub(/^\047/, "", value)
+          sub(/\047$/, "", value)
+        }
         if (tolower(key) == owner) {
           print value
           exit

--- a/codex/scripts/gh-auth-check.sh
+++ b/codex/scripts/gh-auth-check.sh
@@ -5,13 +5,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 resolve_config_path() {
-  if [[ -f "${ROOT_DIR}/codex/codex-config.yaml" ]]; then
-    printf '%s\n' "${ROOT_DIR}/codex/codex-config.yaml"
+  if [[ -f "${ROOT_DIR}/.codex/codex-config.yaml" ]]; then
+    printf '%s\n' "${ROOT_DIR}/.codex/codex-config.yaml"
     return 0
   fi
 
-  if [[ -f "${ROOT_DIR}/.codex/codex-config.yaml" ]]; then
-    printf '%s\n' "${ROOT_DIR}/.codex/codex-config.yaml"
+  if [[ -f "${ROOT_DIR}/codex/codex-config.yaml" ]]; then
+    printf '%s\n' "${ROOT_DIR}/codex/codex-config.yaml"
     return 0
   fi
 

--- a/codex/scripts/gh-wrap.sh
+++ b/codex/scripts/gh-wrap.sh
@@ -5,13 +5,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 resolve_config_path() {
-  if [[ -f "${ROOT_DIR}/codex/codex-config.yaml" ]]; then
-    printf '%s\n' "${ROOT_DIR}/codex/codex-config.yaml"
+  if [[ -f "${ROOT_DIR}/.codex/codex-config.yaml" ]]; then
+    printf '%s\n' "${ROOT_DIR}/.codex/codex-config.yaml"
     return 0
   fi
 
-  if [[ -f "${ROOT_DIR}/.codex/codex-config.yaml" ]]; then
-    printf '%s\n' "${ROOT_DIR}/.codex/codex-config.yaml"
+  if [[ -f "${ROOT_DIR}/codex/codex-config.yaml" ]]; then
+    printf '%s\n' "${ROOT_DIR}/codex/codex-config.yaml"
     return 0
   fi
 

--- a/codex/scripts/gh-wrap.sh
+++ b/codex/scripts/gh-wrap.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+resolve_config_path() {
+  if [[ -f "${ROOT_DIR}/codex/codex-config.yaml" ]]; then
+    printf '%s\n' "${ROOT_DIR}/codex/codex-config.yaml"
+    return 0
+  fi
+
+  if [[ -f "${ROOT_DIR}/.codex/codex-config.yaml" ]]; then
+    printf '%s\n' "${ROOT_DIR}/.codex/codex-config.yaml"
+    return 0
+  fi
+
+  if [[ -f "${HOME}/.codex/codex-config.yaml" ]]; then
+    printf '%s\n' "${HOME}/.codex/codex-config.yaml"
+    return 0
+  fi
+
+  return 1
+}
+
+github_cli_block() {
+  local config_path="$1"
+  awk '
+    /^github_cli:/ { in_block=1; next }
+    in_block && /^[^[:space:]]/ { exit }
+    in_block { print }
+  ' "${config_path}"
+}
+
+configured_token_env_for_owner() {
+  local owner_lc="$1"
+  local config_path="$2"
+
+  github_cli_block "${config_path}" | awk -v owner="${owner_lc}" '
+    /^  owner_token_env:[[:space:]]*$/ { in_map=1; next }
+    in_map && /^  [A-Za-z0-9_.-]+:[[:space:]]*/ { exit }
+    in_map {
+      line=$0
+      if (line ~ /^    /) {
+        key=line
+        value=line
+        sub(/^    /, "", key)
+        sub(/:.*/, "", key)
+        sub(/^    [^:]+:[[:space:]]*/, "", value)
+        gsub(/"/, "", value)
+        sub(/[[:space:]]*$/, "", value)
+        if (tolower(key) == owner) {
+          print value
+          exit
+        }
+      }
+    }
+  '
+}
+
+repo_slug_from_args() {
+  local -a args=("$@")
+  local idx=0
+
+  while (( idx < ${#args[@]} )); do
+    case "${args[idx]}" in
+      --repo|-R)
+        if (( idx + 1 >= ${#args[@]} )); then
+          echo "ERROR: ${args[idx]} requires an owner/repo argument" >&2
+          return 2
+        fi
+        printf '%s\n' "${args[idx + 1]}"
+        return 0
+        ;;
+      --repo=*|-R=*)
+        printf '%s\n' "${args[idx]#*=}"
+        return 0
+        ;;
+    esac
+    idx=$((idx + 1))
+  done
+
+  return 1
+}
+
+repo_slug_from_origin() {
+  local remote_url=""
+  remote_url="$(git config --get remote.origin.url 2>/dev/null || true)"
+
+  if [[ -z "${remote_url}" ]]; then
+    echo "ERROR: unable to infer repository owner/repo from remote.origin.url; pass --repo owner/name" >&2
+    return 2
+  fi
+
+  printf '%s\n' "${remote_url}" | sed -nE 's#^.*github\.com[:/]([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)(\.git)?$#\1#p' | head -n 1
+}
+
+resolve_repo_slug() {
+  local slug=""
+
+  slug="$(repo_slug_from_args "$@" 2>/dev/null || true)"
+  if [[ -n "${slug}" ]]; then
+    printf '%s\n' "${slug}"
+    return 0
+  fi
+
+  slug="$(repo_slug_from_origin)"
+  if [[ -z "${slug}" ]]; then
+    echo "ERROR: unable to resolve GitHub owner/repo" >&2
+    return 2
+  fi
+
+  printf '%s\n' "${slug}"
+}
+
+prepare_github_cli_env() {
+  local slug="$1"
+  local owner="${slug%%/*}"
+  local owner_lc="${owner,,}"
+  local config_path=""
+  local token_env=""
+
+  GH_WRAP_REPO_SLUG="${slug}"
+  GH_WRAP_OWNER="${owner}"
+  GH_WRAP_SELECTED_TOKEN_ENV=""
+
+  config_path="$(resolve_config_path 2>/dev/null || true)"
+  if [[ -n "${config_path}" ]]; then
+    token_env="$(configured_token_env_for_owner "${owner_lc}" "${config_path}")"
+  else
+    token_env=""
+  fi
+
+  if [[ -z "${token_env}" ]]; then
+    return 0
+  fi
+
+  if [[ -z "${!token_env:-}" ]]; then
+    echo "AUTH BLOCKED: owner/org '${owner}' maps to env var '${token_env}', but that env var is unset." >&2
+    echo "Update the environment or adjust github_cli.owner_token_env in codex-config.yaml." >&2
+    return 4
+  fi
+
+  export GH_TOKEN="${!token_env}"
+  GH_WRAP_SELECTED_TOKEN_ENV="${token_env}"
+  return 0
+}
+
+print_gh_wrap_debug() {
+  local -a args=("$@")
+  local token_label="GH_TOKEN (ambient)"
+
+  if [[ -n "${GH_WRAP_SELECTED_TOKEN_ENV:-}" ]]; then
+    token_label="${GH_WRAP_SELECTED_TOKEN_ENV}"
+  fi
+
+  echo "GH_WRAP_DEBUG"
+  echo "repo=${GH_WRAP_REPO_SLUG}"
+  echo "owner=${GH_WRAP_OWNER}"
+  echo "token_env=${token_label}"
+  printf 'command='
+  printf '%q ' gh "${args[@]}"
+  printf '\n'
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./codex/scripts/gh-wrap.sh pr <create|view|edit|list|comment|status|close|reopen> [gh args...]
+  ./codex/scripts/gh-wrap.sh issue <create|delete|edit|list|close|reopen> [gh args...]
+  ./codex/scripts/gh-wrap.sh label create [gh args...]
+  ./codex/scripts/gh-wrap.sh edit [gh args...]   # alias for "pr edit"
+EOF
+}
+
+normalize_command() {
+  local -a args=("$@")
+  if (( ${#args[@]} == 0 )); then
+    usage >&2
+    return 2
+  fi
+
+  case "${args[0]}" in
+    pr)
+      if (( ${#args[@]} < 2 )); then
+        echo "ERROR: missing pr subcommand" >&2
+        return 2
+      fi
+      case "${args[1]}" in
+        create|view|edit|list|comment|status|close|reopen)
+          printf '%s\0' "${args[@]}"
+          return 0
+          ;;
+      esac
+      ;;
+    issue)
+      if (( ${#args[@]} < 2 )); then
+        echo "ERROR: missing issue subcommand" >&2
+        return 2
+      fi
+      case "${args[1]}" in
+        create|delete|edit|list|close|reopen)
+          printf '%s\0' "${args[@]}"
+          return 0
+          ;;
+      esac
+      ;;
+    label)
+      if (( ${#args[@]} >= 2 )) && [[ "${args[1]}" == "create" ]]; then
+        printf '%s\0' "${args[@]}"
+        return 0
+      fi
+      ;;
+    edit)
+      printf '%s\0' pr edit "${args[@]:1}"
+      return 0
+      ;;
+  esac
+
+  echo "ERROR: unsupported gh-wrap command shape" >&2
+  usage >&2
+  return 2
+}
+
+main() {
+  local -a original_args=("$@")
+  local -a normalized_args=()
+  local slug=""
+
+  if (( ${#original_args[@]} > 0 )); then
+    case "${original_args[0]}" in
+      --help|-h)
+        usage
+        return 0
+        ;;
+    esac
+  fi
+
+  while IFS= read -r -d '' item; do
+    normalized_args+=("${item}")
+  done < <(normalize_command "${original_args[@]}")
+
+  slug="$(resolve_repo_slug "${normalized_args[@]}")"
+  prepare_github_cli_env "${slug}"
+
+  if [[ "${GH_WRAP_DEBUG:-0}" == "1" ]]; then
+    print_gh_wrap_debug "${normalized_args[@]}"
+    return 0
+  fi
+
+  exec gh "${normalized_args[@]}"
+}
+
+main "$@"

--- a/codex/skills/land-the-plan/SKILL.md
+++ b/codex/skills/land-the-plan/SKILL.md
@@ -222,24 +222,25 @@ If MCP create/update fails with a permission/auth-access error (for example 401/
 2. if the MCP check finds an existing PR, update that PR via CLI fallback with:
 
 ```bash
-gh pr edit <PR_NUMBER> --title "<PR_TITLE>" --body "<PR_BODY>"
+./codex/scripts/gh-wrap.sh pr edit <PR_NUMBER> --title "<PR_TITLE>" --body "<PR_BODY>"
 ```
 
 3. if the MCP check confirms no existing PR, create one via CLI fallback with:
 
 ```bash
-gh pr create --base <BASE_BRANCH> --head <RESOLVED_HEAD_BRANCH> --title "<PR_TITLE>" --body "<PR_BODY>"
+./codex/scripts/gh-wrap.sh pr create --base <BASE_BRANCH> --head <RESOLVED_HEAD_BRANCH> --title "<PR_TITLE>" --body "<PR_BODY>"
 ```
 
 4. if the MCP check is also unavailable because of permission/auth-access failure, use CLI fallback to detect an existing PR first:
 
 ```bash
-gh pr view <RESOLVED_HEAD_BRANCH> --json number,url
+./codex/scripts/gh-wrap.sh pr view <RESOLVED_HEAD_BRANCH> --json number,url
 ```
 
-5. if `gh pr view` finds an existing PR, update it with `gh pr edit <PR_NUMBER> --title "<PR_TITLE>" --body "<PR_BODY>"`; otherwise run `gh pr create --base <BASE_BRANCH> --head <RESOLVED_HEAD_BRANCH> --title "<PR_TITLE>" --body "<PR_BODY>"`.
-6. if sandbox/network restrictions block CLI fallback, rerun the needed `gh pr view`, `gh pr edit`, or `gh pr create` command with elevated permissions.
-7. on fallback success, record PR URL/number and continue to Step 8.
+5. if `gh-wrap.sh pr view` finds an existing PR, update it with `./codex/scripts/gh-wrap.sh pr edit <PR_NUMBER> --title "<PR_TITLE>" --body "<PR_BODY>"`; otherwise run `./codex/scripts/gh-wrap.sh pr create --base <BASE_BRANCH> --head <RESOLVED_HEAD_BRANCH> --title "<PR_TITLE>" --body "<PR_BODY>"`.
+6. if wrapper fallback reports an auth-block, suggest `./codex/scripts/gh-auth-check.sh [--repo owner/name]` for manual diagnosis; do not run it automatically.
+7. if sandbox/network restrictions block wrapper fallback, rerun the needed wrapper command with elevated permissions.
+8. on fallback success, record PR URL/number and continue to Step 8.
 
 If both MCP and CLI fallback fail:
 
@@ -312,7 +313,7 @@ All gates must pass:
 - Do not modify the retained goal file content during compaction.
 - Do not bypass detached-head branch prep checks when starting from detached `HEAD`.
 - Do not run raw `git push -u origin <branch>`; use `git-push-branch-safe.sh`.
-- Do not use `gh pr create` as first PR method; it is allowed only as fallback after MCP permission/auth-access failure.
+- Do not use raw `gh pr create` as first PR method; wrapper-based CLI fallback is allowed only after MCP permission/auth-access failure.
 - Do not create a duplicate PR when one already exists for the resolved head branch; reuse or update it instead.
 - Do not invent TODO items; only include observed `//TODO`.
 - Do not skip required PR body sections.
@@ -330,7 +331,7 @@ All gates must pass:
   - goal-versions diff path when present
   - removed artifacts count under `goals/<task>/` and `tasks/<task>/`
 - PR URL
-- PR creation method used (`GitHub MCP` or CLI fallback via `gh pr view`/`gh pr edit`/`gh pr create`)
+- PR creation method used (`GitHub MCP` or CLI fallback via `gh-wrap.sh pr view`/`gh-wrap.sh pr edit`/`gh-wrap.sh pr create`)
 - generated PR title
 - generated PR body containing:
   - goals

--- a/goals/gh-wrapper-auth-routing/establish-goals.v0.md
+++ b/goals/gh-wrapper-auth-routing/establish-goals.v0.md
@@ -1,0 +1,90 @@
+# establish-goals
+
+## Status
+
+- Iteration: v0
+- State: locked
+- Task name (proposed, kebab-case): gh-wrapper-auth-routing
+
+## Request restatement
+
+- Implement the issue-38 resolution by replacing direct allowed `gh` command usage with wrapper scripts that own org-aware token selection for GitHub CLI flows, then open a PR to merge the fix into `main`.
+
+## Context considered
+
+- Repo/rules/skills consulted:
+  - `codex/AGENTS.md`
+  - `codex/skills/establish-goals/SKILL.md`
+  - `codex/skills/prepare-takeoff/SKILL.md`
+  - `codex/skills/prepare-phased-impl/SKILL.md`
+  - `codex/skills/implement/SKILL.md`
+  - `codex/skills/land-the-plan/SKILL.md`
+- Relevant files (if any):
+  - `codex/rules/git-safe.rules`
+  - `codex/prompts/self-improve-skills.md`
+  - `codex/skills/land-the-plan/SKILL.md`
+  - `codex/codex-config.yaml`
+  - new wrapper script surface under `codex/scripts/`
+- Constraints (sandbox, commands, policy):
+  - No source-code modification before goals are approved.
+  - Stage order and verification requirements from `codex/AGENTS.md` are mandatory.
+  - The user asked for wrapper-script remediation instead of more raw `gh` rules.
+
+## Ambiguities
+
+### Blocking (must resolve)
+
+1. None.
+
+### Non-blocking (can proceed with explicit assumptions)
+
+1. The issue body typo `gh-wrap.sh edit` refers to `gh-wrap.sh pr edit`.
+2. The issue body typo `gh-wrap.sh lable create` refers to `gh-wrap.sh label create`.
+3. The owner/org token mapping can live in `codex/codex-config.yaml` without introducing secrets because it stores env-var names, not token values.
+4. Verification can use shell-level wrapper probes plus repository validators because this repo does not expose a dedicated automated test harness for live GitHub auth flows.
+
+## Questions for user
+
+1. None.
+
+## Assumptions (explicit; remove when confirmed)
+
+1. Wrapper scripts should be the only repo-approved CLI surface for the listed GitHub operations.
+2. Existing GitHub MCP behavior remains unchanged; only CLI fallback and explicit issue-flow usage move behind wrappers.
+3. `gh-auth-check.sh` is manual-only and must not be invoked automatically by skills.
+
+## Goals
+
+1. Add a repo-level config contract in `codex/codex-config.yaml` for owner/org-specific GitHub CLI token-env selection that falls back to ambient `GH_TOKEN` when no mapping exists.
+2. Add wrapper script support under `codex/scripts/` for the GitHub CLI command families requested in issue `#38`, plus a separate `gh-auth-check.sh` diagnostic surface.
+3. Make the wrappers fail fast with a clear auth-block message when a configured alternate token env var is selected but unset.
+4. Update workflow callsites and guidance so repo-controlled GitHub CLI usage references the wrappers instead of direct raw `gh` commands.
+5. Replace raw `gh` allow rules in `codex/rules/git-safe.rules` with allow rules for the wrapper scripts only, covering the wrapper command surface requested in issue `#38`.
+6. Add verification evidence showing the wrappers preserve default `GH_TOKEN` behavior when no mapping exists and correctly block when a configured mapped env var is missing.
+7. Land the completed fix on a pushed branch and open a reviewer-ready pull request targeting `main`.
+
+## Non-goals
+
+- Changing GitHub MCP authentication behavior or permission routing.
+- Adding automatic execution of the diagnostic auth check during normal agent flows.
+- Implementing live integration tests that require real repository issue mutation across external GitHub repositories.
+
+## Success criteria
+
+> Tie each criterion to a goal number when possible.
+
+- [G1] `codex/codex-config.yaml` documents a stable owner/org-to-token-env mapping contract, and no token secret values are stored in the file.
+- [G2] New wrapper scripts exist under `codex/scripts/` for the requested GitHub CLI surfaces, including `gh-auth-check.sh`.
+- [G3] Wrapper validation demonstrates: no mapping => ambient `GH_TOKEN` path remains usable; configured-but-unset mapping => explicit non-zero auth-block outcome with guidance.
+- [G4] `codex/skills/land-the-plan/SKILL.md` and `codex/prompts/self-improve-skills.md` reference wrapper usage instead of raw direct `gh` invocations where this issue applies.
+- [G5] `codex/rules/git-safe.rules` contains wrapper-script allow rules and no direct `gh` allow entries for the migrated command surface.
+- [G6] Stage validation records the exact lint/build/test outcomes required by the repo contract, plus targeted wrapper checks tied to the config and auth-block behavior.
+- [G7] A pull request to `main` exists for the implementation branch.
+
+## Risks / tradeoffs
+
+- Broad wrapper coverage can drift if the wrapper command surface is expanded beyond the actually needed workflow paths; keep the implementation minimal and traceable to issue `#38`.
+
+## Next action
+
+- Present the extracted goals for approval, then proceed to `prepare-takeoff` only after approval.

--- a/goals/gh-wrapper-auth-routing/goals.v0.md
+++ b/goals/gh-wrapper-auth-routing/goals.v0.md
@@ -1,0 +1,35 @@
+# Goals Extract
+- Task name: gh-wrapper-auth-routing
+- Iteration: v0
+- State: locked
+
+## Goals
+
+1. Add a repo-level config contract in `codex/codex-config.yaml` for owner/org-specific GitHub CLI token-env selection that falls back to ambient `GH_TOKEN` when no mapping exists.
+2. Add wrapper script support under `codex/scripts/` for the GitHub CLI command families requested in issue `#38`, plus a separate `gh-auth-check.sh` diagnostic surface.
+3. Make the wrappers fail fast with a clear auth-block message when a configured alternate token env var is selected but unset.
+4. Update workflow callsites and guidance so repo-controlled GitHub CLI usage references the wrappers instead of direct raw `gh` commands.
+5. Replace raw `gh` allow rules in `codex/rules/git-safe.rules` with allow rules for the wrapper scripts only, covering the wrapper command surface requested in issue `#38`.
+6. Add verification evidence showing the wrappers preserve default `GH_TOKEN` behavior when no mapping exists and correctly block when a configured mapped env var is missing.
+7. Land the completed fix on a pushed branch and open a reviewer-ready pull request targeting `main`.
+
+
+## Non-goals
+
+- Changing GitHub MCP authentication behavior or permission routing.
+- Adding automatic execution of the diagnostic auth check during normal agent flows.
+- Implementing live integration tests that require real repository issue mutation across external GitHub repositories.
+
+
+## Success criteria
+
+> Tie each criterion to a goal number when possible.
+
+- [G1] `codex/codex-config.yaml` documents a stable owner/org-to-token-env mapping contract, and no token secret values are stored in the file.
+- [G2] New wrapper scripts exist under `codex/scripts/` for the requested GitHub CLI surfaces, including `gh-auth-check.sh`.
+- [G3] Wrapper validation demonstrates: no mapping => ambient `GH_TOKEN` path remains usable; configured-but-unset mapping => explicit non-zero auth-block outcome with guidance.
+- [G4] `codex/skills/land-the-plan/SKILL.md` and `codex/prompts/self-improve-skills.md` reference wrapper usage instead of raw direct `gh` invocations where this issue applies.
+- [G5] `codex/rules/git-safe.rules` contains wrapper-script allow rules and no direct `gh` allow entries for the migrated command surface.
+- [G6] Stage validation records the exact lint/build/test outcomes required by the repo contract, plus targeted wrapper checks tied to the config and auth-block behavior.
+- [G7] A pull request to `main` exists for the implementation branch.
+

--- a/goals/task-manifest.csv
+++ b/goals/task-manifest.csv
@@ -15,3 +15,4 @@ number,taskname,first_create_date,first_create_hhmmss,first_create_git_hash
 14,self-improve-skills,2026-03-15,000000,-------
 15,hook-self-improvement,2026-03-15,041906,267111a
 16,fix-open-prompts-issues,2026-03-16,041013,0364e2d
+17,gh-wrapper-auth-routing,2026-03-29,000000,-------

--- a/tasks/gh-wrapper-auth-routing/.complexity-lock.json
+++ b/tasks/gh-wrapper-auth-routing/.complexity-lock.json
@@ -1,0 +1,23 @@
+{
+  "selected_signals_path": "/Users/eric/.codex/worktrees/898e/prompts/tasks/gh-wrapper-auth-routing/complexity-signals.json",
+  "selected_signals_sha256": "da168f9da4d133e5835024890db385cd3a4b7bef12de5fb2ae98b0c027b94acc",
+  "score_script_path": "/Users/eric/.codex/worktrees/898e/prompts/codex/scripts/complexity-score.sh",
+  "score_script_sha256": "45a062dd25a8938ad1fba76e1be65815c40d7d722a20ff07c22c74ed0e479699",
+  "ranges": {
+    "goals": {
+      "min": 3,
+      "max": 5
+    },
+    "phases": {
+      "min": 2,
+      "max": 4
+    }
+  },
+  "recommended": {
+    "goals": 4,
+    "phases": 3
+  },
+  "complexity_input": "@tasks/gh-wrapper-auth-routing/complexity-signals.json",
+  "complexity_descriptor": "scored:L2 (focused)",
+  "captured_at": "2026-03-29T15:52:48Z"
+}

--- a/tasks/gh-wrapper-auth-routing/.scope-lock.md
+++ b/tasks/gh-wrapper-auth-routing/.scope-lock.md
@@ -1,0 +1,13 @@
+## IN SCOPE
+- `codex/codex-config.yaml`
+- `codex/scripts/gh-wrap.sh`
+- `codex/scripts/gh-auth-check.sh`
+- `codex/skills/land-the-plan/SKILL.md`
+- `codex/prompts/self-improve-skills.md`
+- `codex/rules/git-safe.rules`
+- Lifecycle artifacts under `goals/gh-wrapper-auth-routing/` and `tasks/gh-wrapper-auth-routing/`
+
+## OUT OF SCOPE
+- GitHub MCP auth changes.
+- Unrelated GitHub CLI workflows not listed in issue `#38`.
+- Automatic execution of the diagnostic wrapper.

--- a/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/.scope-lock.md
+++ b/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/.scope-lock.md
@@ -1,0 +1,13 @@
+## IN SCOPE
+- `codex/codex-config.yaml`
+- `codex/scripts/gh-wrap.sh`
+- `codex/scripts/gh-auth-check.sh`
+- `codex/skills/land-the-plan/SKILL.md`
+- `codex/prompts/self-improve-skills.md`
+- `codex/rules/git-safe.rules`
+- Lifecycle artifacts under `goals/gh-wrapper-auth-routing/` and `tasks/gh-wrapper-auth-routing/`
+
+## OUT OF SCOPE
+- GitHub MCP auth changes.
+- Unrelated GitHub CLI workflows not listed in issue `#38`.
+- Automatic execution of the diagnostic wrapper.

--- a/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/archive-metadata.md
+++ b/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/archive-metadata.md
@@ -1,0 +1,5 @@
+# Stage 3 Archive Metadata
+- Task name: gh-wrapper-auth-routing
+- Archive GUID: 9d32bc8
+- Archive directory: /Users/eric/.codex/worktrees/898e/prompts/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8
+- Archived by: prepare-phased-impl-archive.sh

--- a/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-1.md
+++ b/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-1.md
@@ -1,0 +1,25 @@
+# Phase 1 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-2.md
+++ b/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-2.md
@@ -1,0 +1,25 @@
+# Phase 2 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-3.md
+++ b/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-3.md
@@ -1,0 +1,25 @@
+# Phase 3 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-4.md
+++ b/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-4.md
@@ -1,0 +1,25 @@
+# Phase 4 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-5.md
+++ b/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-5.md
@@ -1,0 +1,25 @@
+# Phase 5 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-6.md
+++ b/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-6.md
@@ -1,0 +1,25 @@
+# Phase 6 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-7.md
+++ b/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-7.md
@@ -1,0 +1,25 @@
+# Phase 7 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-8.md
+++ b/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-8.md
@@ -1,0 +1,25 @@
+# Phase 8 — <PHASE TITLE>
+
+## Objective
+
+## Code areas impacted
+- `...`
+
+## Work items
+- [ ] …
+
+## Deliverables
+- …
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [ ] …
+
+## Verification steps
+List exact commands and expected results.
+- [ ] Command: `...`
+  - Expected: `...`
+
+## Risks and mitigations
+- Risk:
+- Mitigation:

--- a/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-plan.md
+++ b/tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-plan.md
@@ -1,0 +1,14 @@
+# Phase Plan
+- Task name: gh-wrapper-auth-routing
+- Complexity: scored:L4 (cross-system)
+- Phase count: 8
+- Active phases: 1..8
+- Verdict: PENDING
+
+## Constraints
+- no code/config changes are allowed except phase-plan document updates under ./tasks/*
+- no new scope is allowed; scope drift is BLOCKED
+
+## Complexity scoring details
+- score=16; recommended-goals=10; guardrails-all-true=false; signals=/Users/eric/.codex/worktrees/898e/prompts/tasks/gh-wrapper-auth-routing/complexity-signals.json
+- Ranges: goals=8-13; phases=6-9

--- a/tasks/gh-wrapper-auth-routing/complexity-signals.json
+++ b/tasks/gh-wrapper-auth-routing/complexity-signals.json
@@ -1,0 +1,24 @@
+{
+  "scope": 2,
+  "behavior": 2,
+  "dependency": 2,
+  "uncertainty": 0,
+  "verification": 2,
+  "evidence": {
+    "scope": "files=6 surface=codex config plus scripts plus rules plus workflow docs",
+    "behavior": "wrapper-based GitHub CLI auth routing replaces direct gh guidance and rule usage",
+    "dependency": "interfaces=gh CLI plus repo config parsing plus lifecycle skill prompts",
+    "uncertainty": "known shell patterns with bounded repo-owned flows",
+    "verification": "checks=lint,build,test plus shell syntax and stage validators",
+    "guardrails": "no schema/api contract change; no new external deps; localized surface; reversible with straightforward verification"
+  },
+  "guardrails": {
+    "no_schema_or_api_contract_change": true,
+    "no_new_external_dependencies": true,
+    "localized_surface": true,
+    "reversible_with_straightforward_verification": true
+  },
+  "overrides": {
+    "reason": ""
+  }
+}

--- a/tasks/gh-wrapper-auth-routing/final-phase.md
+++ b/tasks/gh-wrapper-auth-routing/final-phase.md
@@ -1,0 +1,51 @@
+# Final Phase — Hardening, Verification, and Closeout
+
+> Stage 4 completion source of truth:
+> mark items as complete with `[x]`, or leave unchecked with `EVALUATED: <decision + reason>`.
+
+### Documentation updates
+- [x] Update `codex/codex-config.yaml` to document the owner/org token-env wrapper contract.
+- [x] Update `codex/skills/land-the-plan/SKILL.md` to use wrapper-based PR fallback guidance.
+- [x] Update `codex/prompts/self-improve-skills.md` to use wrapper-based issue creation guidance.
+- [x] Update `codex/rules/git-safe.rules` to allow the wrapper scripts instead of the migrated raw `gh` entries.
+- [ ] `/doc`, YAML contracts, README, and ADR updates EVALUATED: not-applicable because this change is limited to lifecycle config, scripts, rules, and prompts.
+
+## Testing closeout
+- [ ] Missing cases to add: live authenticated create/delete diagnostic exercise against a disposable test repository. EVALUATED: deferred because live GitHub mutation is intentionally manual-only.
+- [ ] Coverage gaps: no end-to-end private-repo permission check was run in this sandbox. EVALUATED: deferred because the wrapper contract is verified locally and live auth flows require real credentials.
+
+## Full verification
+> Use the pinned commands in spec + `./codex/project-structure.md` + `./codex/codex-config.yaml`.
+> Stage 4 requires explicit pass notation: `PASS`.
+
+- [x] Lint: `not-configured` PASS
+- [x] Build: `not-configured` PASS
+- [x] Tests: `not-configured` PASS
+- [x] Script syntax: `bash -n codex/scripts/gh-wrap.sh codex/scripts/gh-auth-check.sh` PASS
+- [x] Ambient auth fallback probe: `GH_TOKEN=ambient GH_WRAP_DEBUG=1 ./codex/scripts/gh-wrap.sh pr view --repo ericpassmore/prompts --json number,url` PASS
+- [x] Configured-but-unset wrapper probe: `GH_WRAP_DEBUG=1 ./codex/scripts/gh-wrap.sh pr create --repo example-owner/repo --title Test --body Test` PASS (exit code `4` with expected auth-block)
+- [x] Diagnostic auth-block probe: `./codex/scripts/gh-auth-check.sh --repo example-owner/repo` PASS (exit code `4` with expected auth-block)
+- [x] Wrapper migration scan: `rg -n "gh-wrap.sh|gh-auth-check.sh|gh pr create|gh issue create" codex/skills/land-the-plan/SKILL.md codex/prompts/self-improve-skills.md codex/rules/git-safe.rules` PASS
+- [x] Raw gh rule removal check: `rg -n 'pattern = \["gh",' codex/rules/git-safe.rules` PASS (no matches)
+- [x] Stage 3 validator: `./codex/scripts/prepare-phased-impl-validate.sh gh-wrapper-auth-routing` PASS
+
+## Manual QA (if applicable)
+- [x] Steps: review wrapper debug output and migrated skill/prompt/rule surfaces together.
+- [x] Expected: ambient fallback remains unchanged for unmapped owners, mapped-but-unset owners hard-block clearly, and touched guidance points only reference wrappers.
+
+## Code review checklist
+- [ ] Correctness and edge cases EVALUATED: deferred to Stage 5 `revalidate` review gate.
+- [ ] Error handling / failure modes EVALUATED: deferred to Stage 5 `revalidate` review gate.
+- [ ] Security (secrets, injection, authz/authn) EVALUATED: deferred to Stage 5 `revalidate` review gate.
+- [ ] Performance (DB queries, hot paths, batching) EVALUATED: not-applicable for small shell/config/rule changes.
+- [ ] Maintainability (structure, naming, boundaries) EVALUATED: deferred to Stage 5 `revalidate` review gate.
+- [ ] Consistency with repo conventions EVALUATED: deferred to Stage 5 `revalidate` review gate.
+- [ ] Test quality and determinism EVALUATED: deferred to Stage 5 `revalidate` review gate.
+
+## Release / rollout notes (if applicable)
+- [x] Migration plan: land config, wrappers, skill/prompt text, and rule updates together so no stale raw `gh` guidance remains.
+- [x] Feature flags: n/a.
+- [x] Backout plan: revert touched config, scripts, skills, prompt text, and rules together if wrapper-based CLI auth routing is not desired.
+
+## Outstanding issues (if any)
+- None.

--- a/tasks/gh-wrapper-auth-routing/lifecycle-state.md
+++ b/tasks/gh-wrapper-auth-routing/lifecycle-state.md
@@ -1,0 +1,4 @@
+# Lifecycle State
+- Stage 3 runs: 1
+- Stage 3 current cycle: 2
+- Stage 3 last validated cycle: 2

--- a/tasks/gh-wrapper-auth-routing/phase-1.md
+++ b/tasks/gh-wrapper-auth-routing/phase-1.md
@@ -1,0 +1,36 @@
+# Phase 1 — Add Config Contract and GH Wrapper
+
+## Objective
+Create the config contract and primary GitHub CLI wrapper that resolves owner/org mappings, preserves default ambient auth behavior, and hard-blocks when a configured mapped env var is unset.
+
+## Code areas impacted
+- `codex/codex-config.yaml`
+- `codex/scripts/gh-wrap.sh`
+
+## Work items
+- [x] Add owner/org token-env mapping documentation to `codex/codex-config.yaml`.
+- [x] Implement `codex/scripts/gh-wrap.sh` with supported command-shape validation and owner/org token-env selection.
+- [x] Support the wrapper command families requested in issue `#38`, including `pr`, `issue`, and `label` subcommands plus the `edit` alias.
+
+## Deliverables
+- Updated config contract in `codex/codex-config.yaml`.
+- Executable `codex/scripts/gh-wrap.sh`.
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [x] Wrapper supports the approved command shapes and exits non-zero on unsupported shapes.
+- [x] Wrapper leaves ambient auth untouched when no owner/org mapping exists.
+- [x] Wrapper emits a clear auth-block message when a mapped env var is configured but unset.
+
+## Verification steps
+List exact commands and expected results.
+- [x] Command: `bash -n codex/scripts/gh-wrap.sh`
+  - Expected: exit code `0`. Result: PASS.
+- [x] Command: `GH_TOKEN=ambient GH_WRAP_DEBUG=1 ./codex/scripts/gh-wrap.sh pr view --repo ericpassmore/prompts --json number,url`
+  - Expected: debug output shows ambient auth path because no mapped env var is configured. Result: PASS.
+- [x] Command: `GH_WRAP_DEBUG=1 ./codex/scripts/gh-wrap.sh pr create --repo example-owner/repo --title Test --body Test`
+  - Expected: explicit non-zero auth-block when a mapped env var is selected but unset. Result: PASS (exit code `4` with expected auth-block).
+
+## Risks and mitigations
+- Risk: wrapper parsing could silently allow unsupported command shapes.
+- Mitigation: validate the allowed command families explicitly and fail fast on anything else.

--- a/tasks/gh-wrapper-auth-routing/phase-2.md
+++ b/tasks/gh-wrapper-auth-routing/phase-2.md
@@ -1,0 +1,39 @@
+# Phase 2 — Add Diagnostic Wrapper and Migrate Callsites
+
+## Objective
+Add the manual-only diagnostic wrapper and update repo-owned workflow guidance plus allow rules to use wrapper scripts instead of raw `gh` commands.
+
+## Code areas impacted
+- `codex/scripts/gh-auth-check.sh`
+- `codex/skills/land-the-plan/SKILL.md`
+- `codex/prompts/self-improve-skills.md`
+- `codex/rules/git-safe.rules`
+
+## Work items
+- [x] Implement `codex/scripts/gh-auth-check.sh` with distinct exit codes for login failure versus create/delete permission failure.
+- [x] Update `land-the-plan` CLI fallback guidance to reference `gh-wrap.sh` and `gh-auth-check.sh`.
+- [x] Update `self-improve-skills` CLI guidance to reference `gh-wrap.sh issue create`.
+- [x] Remove direct raw `gh` allow entries and replace them with wrapper-script allow entries for the approved wrapper command surface.
+
+## Deliverables
+- Executable `codex/scripts/gh-auth-check.sh`.
+- Updated skill/prompt guidance and wrapper-script rule entries.
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [x] Repo-owned guidance no longer instructs the affected raw `gh` commands directly.
+- [x] `git-safe.rules` allows the wrapper scripts instead of the migrated raw `gh` entries.
+- [x] Diagnostic wrapper is documented as manual-only.
+
+## Verification steps
+List exact commands and expected results.
+- [x] Command: `bash -n codex/scripts/gh-auth-check.sh`
+  - Expected: exit code `0`. Result: PASS.
+- [x] Command: `rg -n "gh-wrap.sh|gh-auth-check.sh|gh pr create|gh issue create" codex/skills/land-the-plan/SKILL.md codex/prompts/self-improve-skills.md codex/rules/git-safe.rules`
+  - Expected: wrapper references present; migrated raw `gh` instructions/rules removed from touched surfaces. Result: PASS.
+- [x] Command: `./codex/scripts/gh-auth-check.sh --repo example-owner/repo`
+  - Expected: mapped-but-unset env returns explicit non-zero auth-block. Result: PASS (exit code `4` with expected auth-block).
+
+## Risks and mitigations
+- Risk: rule updates could accidentally broaden command access beyond the requested surface.
+- Mitigation: allow only the specific wrapper command patterns requested in issue `#38`.

--- a/tasks/gh-wrapper-auth-routing/phase-3.md
+++ b/tasks/gh-wrapper-auth-routing/phase-3.md
@@ -1,0 +1,34 @@
+# Phase 3 — Verify Wrapper Behavior and Landing Readiness
+
+## Objective
+Run targeted wrapper/config checks, validate lifecycle readiness, and prepare the task for landing without expanding scope.
+
+## Code areas impacted
+- `tasks/gh-wrapper-auth-routing/*`
+- changed files from Phases 1 and 2
+
+## Work items
+- [x] Run targeted wrapper behavior probes for default auth fallback and configured-but-unset mapping failure.
+- [x] Update `final-phase.md` with full verification and checklist evaluation.
+- [x] Run Stage 3 and Stage 4 validators to reach `READY TO LAND`.
+
+## Deliverables
+- Completed task artifacts with verification evidence.
+- `READY TO LAND` stage outcome.
+
+## Gate (must pass before proceeding)
+Define objective pass/fail criteria.
+- [x] Targeted wrapper checks pass with expected outcomes.
+- [x] `prepare-phased-impl-validate.sh` and `implement-validate.sh` pass for this task.
+- [x] No unresolved actionable issues remain before landing.
+
+## Verification steps
+List exact commands and expected results.
+- [x] Command: `./codex/scripts/prepare-phased-impl-validate.sh gh-wrapper-auth-routing`
+  - Expected: `READY FOR IMPLEMENTATION`. Result: PASS.
+- [x] Command: `./codex/scripts/implement-validate.sh gh-wrapper-auth-routing`
+  - Expected: `READY TO LAND`. Result: PASS.
+
+## Risks and mitigations
+- Risk: wrapper verification could rely on live GitHub state and become flaky.
+- Mitigation: keep Stage 4 checks focused on deterministic local wrapper behavior and syntax, and leave live auth mutation to the manual diagnostic wrapper.

--- a/tasks/gh-wrapper-auth-routing/phase-plan.md
+++ b/tasks/gh-wrapper-auth-routing/phase-plan.md
@@ -1,0 +1,14 @@
+# Phase Plan
+- Task name: gh-wrapper-auth-routing
+- Complexity: scored:L2 (focused)
+- Phase count: 3
+- Active phases: 1..3
+- Verdict: READY TO LAND
+
+## Constraints
+- no code/config changes are allowed except phase-plan document updates under ./tasks/*
+- no new scope is allowed; scope drift is BLOCKED
+
+## Complexity scoring details
+- score=8; recommended-goals=4; guardrails-all-true=true; signals=/Users/eric/.codex/worktrees/898e/prompts/tasks/gh-wrapper-auth-routing/complexity-signals.json
+- Ranges: goals=3-5; phases=2-4

--- a/tasks/gh-wrapper-auth-routing/revalidate-code-review.md
+++ b/tasks/gh-wrapper-auth-routing/revalidate-code-review.md
@@ -1,0 +1,130 @@
+# Revalidate Code Review
+- Task name: gh-wrapper-auth-routing
+- Findings status: none
+
+## Reviewer Prompt
+You are acting as a reviewer for a proposed code change made by another engineer.
+Focus on issues that impact correctness, performance, security, maintainability, or developer experience.
+Flag only actionable issues introduced by the pull request.
+When you flag an issue, provide a short, direct explanation and cite the affected file and line range.
+Prioritize severe issues and avoid nit-level comments unless they block understanding of the diff.
+After listing findings, produce an overall correctness verdict ("patch is correct" or "patch is incorrect") with a concise justification and a confidence score between 0 and 1.
+Ensure that file citations and line numbers are exactly correct using the tools available; if they are incorrect your comments will be rejected.
+
+## Output Schema
+```json
+[
+  {
+    "file": "path/to/file",
+    "line_range": "10-25",
+    "severity": "high",
+    "explanation": "Short explanation."
+  }
+]
+```
+
+## Review Context (auto-generated)
+<!-- REVIEW-CONTEXT START -->
+- Generated at: 2026-03-29T16:06:52Z
+- Base branch: main
+- Diff mode: fallback
+- Diff command: `git diff`
+- Diff bytes: 71014
+
+### Changed files
+- `codex/codex-config.yaml`
+- `codex/prompts/self-improve-skills.md`
+- `codex/rules/git-safe.rules`
+- `codex/scripts/gh-auth-check.sh`
+- `codex/scripts/gh-wrap.sh`
+- `codex/skills/land-the-plan/SKILL.md`
+- `goals/gh-wrapper-auth-routing/establish-goals.v0.md`
+- `goals/gh-wrapper-auth-routing/goals.v0.md`
+- `goals/task-manifest.csv`
+- `tasks/gh-wrapper-auth-routing/.complexity-lock.json`
+- `tasks/gh-wrapper-auth-routing/.scope-lock.md`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/.scope-lock.md`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/archive-metadata.md`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-1.md`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-2.md`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-3.md`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-4.md`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-5.md`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-6.md`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-7.md`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-8.md`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-plan.md`
+- `tasks/gh-wrapper-auth-routing/complexity-signals.json`
+- `tasks/gh-wrapper-auth-routing/final-phase.md`
+- `tasks/gh-wrapper-auth-routing/lifecycle-state.md`
+- `tasks/gh-wrapper-auth-routing/phase-1.md`
+- `tasks/gh-wrapper-auth-routing/phase-2.md`
+- `tasks/gh-wrapper-auth-routing/phase-3.md`
+- `tasks/gh-wrapper-auth-routing/phase-plan.md`
+- `tasks/gh-wrapper-auth-routing/revalidate-code-review.md`
+- `tasks/gh-wrapper-auth-routing/risk-acceptance.md`
+- `tasks/gh-wrapper-auth-routing/spec.md`
+
+### Citation candidates (verify before use)
+- `codex/codex-config.yaml:11-14`
+- `codex/codex-config.yaml:30-31`
+- `codex/codex-config.yaml:4-7`
+- `codex/prompts/self-improve-skills.md:95-95`
+- `codex/prompts/self-improve-skills.md:98-98`
+- `codex/rules/git-safe.rules:121-121`
+- `codex/rules/git-safe.rules:123-123`
+- `codex/rules/git-safe.rules:125-125`
+- `codex/rules/git-safe.rules:130-130`
+- `codex/rules/git-safe.rules:132-132`
+- `codex/rules/git-safe.rules:134-134`
+- `codex/rules/git-safe.rules:139-139`
+- `codex/rules/git-safe.rules:141-141`
+- `codex/rules/git-safe.rules:143-143`
+- `codex/rules/git-safe.rules:148-148`
+- `codex/rules/git-safe.rules:150-150`
+- `codex/rules/git-safe.rules:152-270`
+- `codex/scripts/gh-auth-check.sh:1-208`
+- `codex/scripts/gh-wrap.sh:1-254`
+- `codex/skills/land-the-plan/SKILL.md:225-225`
+- `codex/skills/land-the-plan/SKILL.md:231-231`
+- `codex/skills/land-the-plan/SKILL.md:237-237`
+- `codex/skills/land-the-plan/SKILL.md:240-243`
+- `codex/skills/land-the-plan/SKILL.md:316-316`
+- `codex/skills/land-the-plan/SKILL.md:334-334`
+- `goals/gh-wrapper-auth-routing/establish-goals.v0.md:1-90`
+- `goals/gh-wrapper-auth-routing/goals.v0.md:1-35`
+- `goals/task-manifest.csv:18-18`
+- `tasks/gh-wrapper-auth-routing/.complexity-lock.json:1-23`
+- `tasks/gh-wrapper-auth-routing/.scope-lock.md:1-13`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/.scope-lock.md:1-13`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/archive-metadata.md:1-5`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-1.md:1-25`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-2.md:1-25`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-3.md:1-25`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-4.md:1-25`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-5.md:1-25`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-6.md:1-25`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-7.md:1-25`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-8.md:1-25`
+- `tasks/gh-wrapper-auth-routing/archive/prepare-phased-impl-9d32bc8/phase-plan.md:1-14`
+- `tasks/gh-wrapper-auth-routing/complexity-signals.json:1-24`
+- `tasks/gh-wrapper-auth-routing/final-phase.md:1-51`
+- `tasks/gh-wrapper-auth-routing/lifecycle-state.md:1-4`
+- `tasks/gh-wrapper-auth-routing/phase-1.md:1-36`
+- `tasks/gh-wrapper-auth-routing/phase-2.md:1-39`
+- `tasks/gh-wrapper-auth-routing/phase-3.md:1-34`
+- `tasks/gh-wrapper-auth-routing/phase-plan.md:1-14`
+- `tasks/gh-wrapper-auth-routing/revalidate-code-review.md:1-130`
+- `tasks/gh-wrapper-auth-routing/risk-acceptance.md:1-11`
+- `tasks/gh-wrapper-auth-routing/spec.md:1-156`
+<!-- REVIEW-CONTEXT END -->
+
+## Findings JSON
+```json
+[]
+```
+
+## Overall Correctness Verdict
+- Verdict: patch is correct
+- Confidence: 0.91
+- Justification: The patch keeps scope limited to the requested wrapper-auth routing surfaces, adds deterministic local checks for ambient fallback and configured-but-unset mappings, and updates the repo-owned rule/guidance surfaces to use the wrappers instead of raw `gh` commands.

--- a/tasks/gh-wrapper-auth-routing/risk-acceptance.md
+++ b/tasks/gh-wrapper-auth-routing/risk-acceptance.md
@@ -1,0 +1,11 @@
+# Risk Acceptance
+
+- Owner:
+- Justification:
+- Expiry: YYYY-MM-DD
+
+## Unresolved actionable findings
+- File:
+- Line range:
+- Severity:
+- Explanation:

--- a/tasks/gh-wrapper-auth-routing/spec.md
+++ b/tasks/gh-wrapper-auth-routing/spec.md
@@ -1,0 +1,156 @@
+# GH Wrapper Auth Routing
+
+## Stage status
+- establish-goals verdict: `GOALS LOCKED` (`goals/gh-wrapper-auth-routing/goals.v0.md`)
+- prepare-takeoff verdict: `READY FOR PLANNING`
+- Stage 2 evidence:
+  - Bootstrap config updated: `codex/codex-config.yaml`
+  - Task scaffold created: `tasks/gh-wrapper-auth-routing/`
+  - Safety prep executed: `./codex/scripts/prepare-takeoff-worktree.sh gh-wrapper-auth-routing codex/gh-wrapper-auth-routing`
+
+## Overview
+Implement issue `#38` by routing repo-controlled GitHub CLI usage through wrapper scripts that choose owner/org-specific token env vars, fall back to ambient `GH_TOKEN`, and fail fast when a configured mapped env var is missing.
+
+## Goals
+1. Add a repo-level config contract in `codex/codex-config.yaml` for owner/org-specific GitHub CLI token-env selection that falls back to ambient `GH_TOKEN` when no mapping exists.
+2. Add wrapper script support under `codex/scripts/` for the GitHub CLI command families requested in issue `#38`, plus a separate `gh-auth-check.sh` diagnostic surface.
+3. Make the wrappers fail fast with a clear auth-block message when a configured alternate token env var is selected but unset.
+4. Update workflow callsites and guidance so repo-controlled GitHub CLI usage references the wrappers instead of direct raw `gh` commands.
+5. Replace raw `gh` allow rules in `codex/rules/git-safe.rules` with allow rules for the wrapper scripts only, covering the wrapper command surface requested in issue `#38`.
+6. Add verification evidence showing the wrappers preserve default `GH_TOKEN` behavior when no mapping exists and correctly block when a configured mapped env var is missing.
+7. Land the completed fix on a pushed branch and open a reviewer-ready pull request targeting `main`.
+
+## Non-goals
+- Changing GitHub MCP authentication behavior or permission routing.
+- Adding automatic execution of the diagnostic auth check during normal agent flows.
+- Implementing live integration tests that require real repository issue mutation across external GitHub repositories.
+
+## Use cases / user stories
+- As an agent invoking repo-approved GitHub CLI flows, I use wrapper scripts instead of raw `gh` commands.
+- As a maintainer working across multiple owners/orgs, I can map a specific owner/org to a different token env var without storing secrets in repo config.
+- As an operator, I can run a manual auth diagnostic that distinguishes login failure from insufficient issue create/delete permission.
+
+## Current behavior
+- Notes:
+  - `land-the-plan` still documents raw `gh pr view|edit|create` fallback commands.
+  - `self-improve-skills` still documents raw `gh issue create`.
+  - `git-safe.rules` still allows direct `gh pr create|view|edit` and `gh issue create`.
+  - `codex/codex-config.yaml` has no owner/org token-env mapping contract.
+- Key files:
+  - `codex/codex-config.yaml`
+  - `codex/scripts/`
+  - `codex/skills/land-the-plan/SKILL.md`
+  - `codex/prompts/self-improve-skills.md`
+  - `codex/rules/git-safe.rules`
+
+## Proposed behavior
+- Behavior changes:
+  - A wrapper script resolves the target owner/org, selects a configured token env var when present, and executes `gh` with scoped `GH_TOKEN` rebinding only for the child process.
+  - A manual-only diagnostic wrapper checks login state and create/delete issue access without being run automatically by agents.
+  - Workflow guidance and rule allowlists point to wrapper scripts instead of raw `gh`.
+- Edge cases:
+  - If no owner/org mapping exists, wrappers leave ambient auth untouched.
+  - If a mapping exists but the named env var is unset, wrappers exit non-zero with a clear auth-block message.
+  - Diagnostic operations must require explicit invocation and clean up the temporary issue on success.
+
+## Technical design
+### Architecture / modules impacted
+- `codex/codex-config.yaml`
+- `codex/scripts/gh-wrap.sh`
+- `codex/scripts/gh-auth-check.sh`
+- `codex/skills/land-the-plan/SKILL.md`
+- `codex/prompts/self-improve-skills.md`
+- `codex/rules/git-safe.rules`
+
+### Stage 2 governing context
+- Rules:
+  - `codex/rules/expand-task-spec.rules`
+  - `codex/rules/git-safe.rules`
+- Skills:
+  - `codex/skills/prepare-takeoff/SKILL.md`
+  - `codex/skills/prepare-phased-impl/SKILL.md`
+  - `codex/skills/implement/SKILL.md`
+  - `codex/skills/land-the-plan/SKILL.md`
+- Sandbox constraints:
+  - Workspace-write filesystem sandbox
+  - Networked GitHub operations require auth and may require escalation at runtime
+
+### API changes (if any)
+- None.
+
+### UI/UX changes (if any)
+- None.
+
+### Data model / schema changes (PostgreSQL)
+- Migrations: none
+- Backward compatibility: full; unmapped owners/orgs continue to use ambient auth
+- Rollback: revert the config, wrapper scripts, skill/prompt text, and rule entries together
+
+## Security & privacy
+- Config stores env-var names only, never token values.
+- Wrappers scope any `GH_TOKEN` rebinding to the child `gh` process.
+- Removing raw `gh` rule entries narrows the direct command surface exposed to agents.
+
+## Observability (logs/metrics)
+- Wrapper failures should print explicit owner/org, selected env-var name, and failure reason.
+- The diagnostic wrapper should print which step failed: login, create, or delete.
+
+## Verification Commands
+> Pin the exact commands discovered for this repo (also update `./codex/project-structure.md` and `./codex/codex-config.yaml` if canon changes).
+
+- Lint:
+  - `not-configured`
+- Build:
+  - `not-configured`
+- Test:
+  - `not-configured`
+- Targeted checks:
+  - `bash -n codex/scripts/gh-wrap.sh codex/scripts/gh-auth-check.sh`
+  - `rg -n "gh-wrap.sh|gh-auth-check.sh|gh pr |gh issue create" codex/skills/land-the-plan/SKILL.md codex/prompts/self-improve-skills.md codex/rules/git-safe.rules`
+  - `./codex/scripts/prepare-phased-impl-validate.sh gh-wrapper-auth-routing`
+  - `./codex/scripts/implement-validate.sh gh-wrapper-auth-routing`
+
+## Test strategy
+- Unit:
+  - Shell syntax checks for the new wrapper scripts.
+- Integration:
+  - Wrapper dry-run style probes for mapping resolution and configured-but-unset env behavior.
+  - Stage validator runs for planning and implementation readiness.
+- E2E / UI (if applicable):
+  - n/a
+
+## Acceptance criteria checklist
+- [x] Scope is limited to config, wrapper scripts, workflow guidance, rule entries, and lifecycle artifacts tied to issue `#38`.
+- [x] GitHub MCP behavior remains unchanged.
+- [x] Verification commands are pinned to repo-local commands or explicit `not-configured` outcomes.
+- [x] No unresolved blocking ambiguity remains for Stage 2.
+
+## IN SCOPE
+- `codex/codex-config.yaml`
+- `codex/scripts/gh-wrap.sh`
+- `codex/scripts/gh-auth-check.sh`
+- `codex/skills/land-the-plan/SKILL.md`
+- `codex/prompts/self-improve-skills.md`
+- `codex/rules/git-safe.rules`
+- Lifecycle artifacts under `goals/gh-wrapper-auth-routing/` and `tasks/gh-wrapper-auth-routing/`
+
+## OUT OF SCOPE
+- GitHub MCP auth changes.
+- Unrelated GitHub CLI workflows not listed in issue `#38`.
+- Automatic execution of the diagnostic wrapper.
+
+## Execution posture lock
+- Simplicity bias: required.
+- Surgical-change discipline: required.
+- Fail-fast error handling: required.
+
+## Change control
+- Locked goals, constraints, and success criteria from `goals/gh-wrapper-auth-routing/goals.v0.md` are immutable unless relocked through `establish-goals`.
+- Scope expansion, verification weakening, or behavior not traceable to the locked goals is drift and must stop the stage.
+- Override authority for goal or constraint changes is a new approved establish-goals iteration.
+
+## Implementation phase strategy
+- Complexity: scored:L2 (focused)
+- Complexity scoring details: score=8; recommended-goals=4; guardrails-all-true=true; signals=/Users/eric/.codex/worktrees/898e/prompts/tasks/gh-wrapper-auth-routing/complexity-signals.json
+- Active phases: 1..3
+- No new scope introduced: required


### PR DESCRIPTION
## Goals
- Add wrapper-based GitHub CLI auth routing for repo-controlled `gh` flows.
- Support owner/org-specific token-env selection with fallback to ambient `GH_TOKEN`.
- Provide a manual-only `gh-auth-check.sh` diagnostic path.
- Replace raw `gh` allow rules and workflow guidance with wrapper-script usage.

## Non-goals
- Changing GitHub MCP authentication behavior.
- Running the diagnostic wrapper automatically.
- Adding live external GitHub integration tests in this repo.

## ADR
- Use repo-owned wrapper scripts as the only allowed GitHub CLI execution surface.
- Keep token selection in `codex/codex-config.yaml` as env-var names only, never secret values.
- Fail fast when a configured owner/org mapping points at an unset env var.

## Exceptions
- `codex/codex-config.yaml` still carries the worktree bootstrap paths required by this repo's lifecycle tooling.
- The diagnostic wrapper is verified locally via the configured-but-unset auth-block path; live create/delete mutation remains manual-only.

## Deferred work
- None.

## Verification
- `bash -n codex/scripts/gh-wrap.sh codex/scripts/gh-auth-check.sh`
- `GH_TOKEN=ambient GH_WRAP_DEBUG=1 ./codex/scripts/gh-wrap.sh pr view --repo ericpassmore/prompts --json number,url`
- `GH_WRAP_DEBUG=1 ./codex/scripts/gh-wrap.sh pr create --repo example-owner/repo --title Test --body Test`
- `./codex/scripts/gh-auth-check.sh --repo example-owner/repo`
- `./codex/scripts/prepare-phased-impl-validate.sh gh-wrapper-auth-routing`
- `./codex/scripts/implement-validate.sh gh-wrapper-auth-routing`
- `./codex/scripts/revalidate-code-review.sh gh-wrapper-auth-routing main`

Closes #38.
